### PR TITLE
process message for evaluate, step_begin and init_evaluate log-event

### DIFF
--- a/training/benchmarks/driver/log_event.py
+++ b/training/benchmarks/driver/log_event.py
@@ -9,6 +9,7 @@ STACKLEVEL = 4
 
 
 class LogEventManager(EventManager):
+    """LogEventManager"""
 
     def __init__(self,
                  local_rank,
@@ -21,44 +22,58 @@ class LogEventManager(EventManager):
                                                               level=level)
 
     def on_launch_training(self):
+        """on launch_training"""
         self._log_event(Event.LAUNCH_TRAINING,
                         "Launch training",
                         stacklevel=STACKLEVEL)
 
     def on_init_evaluation(self, result: dict):
-        self._log_event(Event.INIT_EVALUATION, result)
+        """on init_evaluation"""
+        self._log_event(Event.INIT_EVALUATION, message=result)
 
     def on_evaluate(self, result: dict):
-        self._log_event(Event.EVALUATE, result)
+        """evaluate event"""
+        self._log_event(Event.EVALUATE, message=result)
 
     def on_backward(self, step: int, loss, optimizer, grad_scaler=None):
+        """on backward"""
         pass
         #self._log_event(Event.BACKWARD, f"step: {step}  loss: {loss}")
 
     def on_init_start(self):
+        """on init_start"""
         self._log_event(Event.INIT_START)
 
     def on_init_end(self):
-        self._log_event(Event.INIT_END, "Finish initialization")
+        """on init_end"""
+        self._log_event(Event.INIT_END, message="Finish initialization")
 
     def on_train_start(self):
+        """on train_start"""
         self._log_event(Event.TRAIN_START)
 
     def on_train_end(self):
+        """on train_end"""
         self._log_event(Event.TRAIN_END)
 
     def on_epoch_begin(self, epoch: int):
+        """on epoch_begin"""
         epoch_info = dict(epoch=epoch)
         self._log_event(Event.EPOCH_BEGIN, epoch_info)
 
     def on_epoch_end(self, epoch: int):
+        """on epoch_end"""
         epoch_info = dict(epoch=epoch)
         self._log_event(Event.EPOCH_END, epoch_info)
 
     def on_step_begin(self, step: int = None):
-        pass
+        """on step_begin"""
+        if (self.log_freq <= 0 or step % self.log_freq != 0) and step != 1:
+            return
+        self._log_event(Event.STEP_BEGIN, step=step)
 
     def on_step_end(self, step: int = None, loss=None, message=None):
+        """step_end event"""
         if (self.log_freq <= 0 or step % self.log_freq != 0) and step != 1:
             return
         self._log_event(Event.STEP_END, message=message)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10068952/226498069-32f39a01-a602-44b2-935c-ae425dc778b9.png)

*args was not used for function _encode_message, so logging message should be passed as message or keyword args.
