### PR TITLE
GLM: add kunlunxin 1x1, 1x2, 1x4, and 2x8 configs

### DIFF
--- a/training/kunlunxin/glm-pytorch/README.md
+++ b/training/kunlunxin/glm-pytorch/README.md
@@ -15,7 +15,7 @@
   - OS kernel版本: 5.4.0-26-generic
   - 加速卡驱动版本：4.0.25
   - Docker镜像和版本：pytorch1.12.1-cpu-ubuntu18.04:v0.04
-  - 训练框架版本：xmlir+85c74eff
+  - 训练框架版本：xmlir+e70db8f6
   - 依赖软件版本：pytorch-1.12.1+cpu
 
 ### 测试运行方法
@@ -32,7 +32,11 @@ ACCE_CONTAINER_OPT = " --device=/dev/xpu0 --device=/dev/xpu1 --device=/dev/xpu2"
 ACCE_VISIBLE_DEVICE_ENV_NAME = "XPU_VISIBLE_DEVICES"
 
 CASES = [
-    "GLM_TORCH_DEMO_R300_1X8"
+    "GLM_TORCH_DEMO_R300_1X1",
+    "GLM_TORCH_DEMO_R300_1X2",
+    "GLM_TORCH_DEMO_R300_1X4",
+    "GLM_TORCH_DEMO_R300_1X8",
+    "GLM_TORCH_DEMO_R300_2X8"
 ]
 ```
 
@@ -43,8 +47,11 @@ CASES = [
 
 | 训练资源 | 配置文件        | 运行时长(s) | 目标精度 | 收敛精度 | Steps数 | 性能(samples/s) |
 |---------| --------------- | ----------- | -------- | -------- | ------- | ---------------- |
+| 单机1卡  | config_R300x1x1 | 121371.25| 0.8 | 0.8021   | 14400(fp32)| 0.50 |
+| 单机2卡  | config_R300x1x2 | 106709.60| 0.8 | 0.8085   | 12000(fp32)| 0.92 |
+| 单机4卡  | config_R300x1x4 | 44162.12 | 0.8 | 0.8027   | 4800(fp32) | 1.79 |
 | 单机8卡  | config_R300x1x8 | 22902.82 | 0.8 | 0.8003   | 2400(fp32) | 3.47 |
-| 两机8卡  | config_R300x2x8 | N/A     | N/A | N/A   | N/A     | N/A            |
+| 两机8卡  | config_R300x2x8 | 16217.80 | 0.8 | 0.8012   | 1500(fp32) | 6.08 |
 
 ### 许可证
 

--- a/training/kunlunxin/glm-pytorch/config/config_R300x1x1.py
+++ b/training/kunlunxin/glm-pytorch/config/config_R300x1x1.py
@@ -1,0 +1,21 @@
+vendor = 'kunlunxin'
+fp16 = False
+
+train_batch_size = 4
+eval_batch_size = 6
+
+dist_backend = "xccl"
+
+lr = 1e-5
+weight_decay = 0.1
+adam_beta1 = 0.9
+adam_beta2 = 0.999
+adam_eps = 1e-08
+gradient_accumulation_steps = 1
+warmup = 0.1
+lr_decay_ratio = 0.1
+lr_decay_iters = 4338
+log_freq = 1
+seed = 4096
+max_samples_termination = 5553080
+training_event = None

--- a/training/kunlunxin/glm-pytorch/config/config_R300x1x2.py
+++ b/training/kunlunxin/glm-pytorch/config/config_R300x1x2.py
@@ -1,0 +1,21 @@
+vendor = 'kunlunxin'
+fp16 = False
+
+train_batch_size = 4
+eval_batch_size = 6
+
+dist_backend = "xccl"
+
+lr = 1e-5
+weight_decay = 0.1
+adam_beta1 = 0.9
+adam_beta2 = 0.999
+adam_eps = 1e-08
+gradient_accumulation_steps = 1
+warmup = 0.1
+lr_decay_ratio = 0.1
+lr_decay_iters = 4338
+log_freq = 1
+seed = 4096
+max_samples_termination = 5553080
+training_event = None

--- a/training/kunlunxin/glm-pytorch/config/config_R300x1x4.py
+++ b/training/kunlunxin/glm-pytorch/config/config_R300x1x4.py
@@ -1,0 +1,21 @@
+vendor = 'kunlunxin'
+fp16 = False
+
+train_batch_size = 4
+eval_batch_size = 6
+
+dist_backend = "xccl"
+
+lr = 1e-5
+weight_decay = 0.1
+adam_beta1 = 0.9
+adam_beta2 = 0.999
+adam_eps = 1e-08
+gradient_accumulation_steps = 1
+warmup = 0.1
+lr_decay_ratio = 0.1
+lr_decay_iters = 4338
+log_freq = 1
+seed = 4096
+max_samples_termination = 5553080
+training_event = None

--- a/training/kunlunxin/glm-pytorch/config/config_R300x2x8.py
+++ b/training/kunlunxin/glm-pytorch/config/config_R300x2x8.py
@@ -1,0 +1,21 @@
+vendor = 'kunlunxin'
+fp16 = False
+
+train_batch_size = 4
+eval_batch_size = 6
+
+dist_backend = "xccl"
+
+lr = 1e-5
+weight_decay = 0.1
+adam_beta1 = 0.9
+adam_beta2 = 0.999
+adam_eps = 1e-08
+gradient_accumulation_steps = 1
+warmup = 0.1
+lr_decay_ratio = 0.1
+lr_decay_iters = 4338
+log_freq = 1
+seed = 4096
+max_samples_termination = 5553080
+training_event = None

--- a/training/kunlunxin/glm-pytorch/config/environment_variables.sh
+++ b/training/kunlunxin/glm-pytorch/config/environment_variables.sh
@@ -4,6 +4,8 @@
 
 export BKCL_PCIE_RING=1
 export BKCL_TIMEOUT=1800
+# when using tree allreduce, the number of nodes must be a multiple of 2
+export BKCL_SOCKET_FORCE_TREE=1
 
 export ALLREDUCE_ASYNC=false
 export ALLREDUCE_FUSION=0

--- a/training/run_benchmarks/config/test_conf.py
+++ b/training/run_benchmarks/config/test_conf.py
@@ -166,12 +166,56 @@ CPM_TORCH_DEMO_A100_1X8 = {
     "data_dir_container": "/mnt/data/cpm/train/",
 }
 
+GLM_TORCH_DEMO_R300_1X1 = {
+    "model": "glm",
+    "framework": "pytorch",
+    "config": "config_R300x1x1",
+    "repeat": 1,
+    "nnodes": 1,
+    "nproc": 1,
+    "data_dir_host": "/home/datasets_ckpt/glm/train/",
+    "data_dir_container": "/mnt/data/glm/train/",
+}
+
+GLM_TORCH_DEMO_R300_1X2 = {
+    "model": "glm",
+    "framework": "pytorch",
+    "config": "config_R300x1x2",
+    "repeat": 1,
+    "nnodes": 1,
+    "nproc": 2,
+    "data_dir_host": "/home/datasets_ckpt/glm/train/",
+    "data_dir_container": "/mnt/data/glm/train/",
+}
+
+GLM_TORCH_DEMO_R300_1X4 = {
+    "model": "glm",
+    "framework": "pytorch",
+    "config": "config_R300x1x4",
+    "repeat": 1,
+    "nnodes": 1,
+    "nproc": 4,
+    "data_dir_host": "/home/datasets_ckpt/glm/train/",
+    "data_dir_container": "/mnt/data/glm/train/",
+}
+
 GLM_TORCH_DEMO_R300_1X8 = {
     "model": "glm",
     "framework": "pytorch",
     "config": "config_R300x1x8",
     "repeat": 1,
     "nnodes": 1,
+    "nproc": 8,
+    "data_dir_host": "/home/datasets_ckpt/glm/train/",
+    "data_dir_container": "/mnt/data/glm/train/",
+}
+
+GLM_TORCH_DEMO_R300_2X8 = {
+    "model": "glm",
+    "framework": "pytorch",
+    "config": "config_R300x2x8",
+    "repeat": 1,
+    "nnodes": 2,
     "nproc": 8,
     "data_dir_host": "/home/datasets_ckpt/glm/train/",
     "data_dir_container": "/mnt/data/glm/train/",


### PR DESCRIPTION
Provement:
[kunlunxin_glm_1x1.log](https://github.com/FlagOpen/FlagPerf/files/11206814/rank0.out.log)
[kunlunxin_glm_1x2.log](https://github.com/FlagOpen/FlagPerf/files/11206809/rank0.out.log)
[kunlunxin_glm_1x4.log](https://github.com/FlagOpen/FlagPerf/files/11206807/rank0.out.log)
[kunlunxin_glm_2x8.log](https://github.com/FlagOpen/FlagPerf/files/11206818/rank0.out.log)
