### PR TITLE
improve logger

### DIFF
--- a/training/run_benchmarks/run.py
+++ b/training/run_benchmarks/run.py
@@ -523,10 +523,14 @@ def main():
     # Set logger first
     timestamp_log_dir = "run" + time.strftime("%Y%m%d%H%M%S", time.localtime())
     curr_log_path = os.path.join(tc.FLAGPERF_LOG_PATH, timestamp_log_dir)
+    stdout = sys.stdout
+    nullout = open("/dev/null", "w")
     RUN_LOGGER.init(curr_log_path,
                     "flagperf_run.log",
                     tc.FLAGPERF_LOG_LEVEL,
                     "both",
+                    stdout,
+                    nullout,
                     log_caller=True)
 
     RUN_LOGGER.info("======== Step 1: Check environment and configs. ========")

--- a/training/utils/flagperf_logger.py
+++ b/training/utils/flagperf_logger.py
@@ -12,6 +12,7 @@
 import os
 import logging
 import datetime
+import sys
 
 LOGLEVELS = {
     'debug': logging.DEBUG,
@@ -82,6 +83,16 @@ def _get_caller():
     return caller
 
 
+def logger_print(method):
+
+    def wrapper(self, msg):
+        sys.stdout = self.stdout
+        method(self, msg)
+        sys.stdout = self.nullout
+
+    return wrapper
+
+
 class FlagPerfLogger():
     '''A logger for benchmark.'''
 
@@ -101,6 +112,8 @@ class FlagPerfLogger():
              logfile,
              loglevel='info',
              mode="file",
+             stdout=sys.stdout,
+             nullout=sys.stdout,
              log_caller=False):
         '''Set log level and create the log file.
            Arguments:
@@ -136,6 +149,9 @@ class FlagPerfLogger():
             self.console_handler = logging.StreamHandler()
             self.console_handler.setFormatter(color_handler_formatter)
             self.perf_logger.addHandler(self.console_handler)
+        sys.stdout = nullout
+        self.stdout = stdout
+        self.nullout = nullout
 
     def stop(self):
         '''If any file opened, close here. Then remove handdlers.'''
@@ -146,6 +162,7 @@ class FlagPerfLogger():
         if self.mode == "both" or self.mode == "console":
             self.perf_logger.removeHandler(self.console_handler)
 
+    @logger_print
     def info(self, msg):
         '''Call logging.info() to log time, log level and msg.'''
         if self.log_caller:
@@ -155,6 +172,7 @@ class FlagPerfLogger():
         else:
             self.perf_logger.info(msg)
 
+    @logger_print
     def warning(self, msg):
         '''Call logging.warning() to log time, log level and msg.'''
         if self.log_caller:
@@ -164,6 +182,7 @@ class FlagPerfLogger():
         else:
             self.perf_logger.warning(msg)
 
+    @logger_print
     def debug(self, msg):
         '''Call logging.debug() to log time, log level and msg.'''
         if self.log_caller:
@@ -173,6 +192,7 @@ class FlagPerfLogger():
         else:
             self.perf_logger.debug(msg)
 
+    @logger_print
     def error(self, msg):
         '''Call logging.error() to log time, log level and msg.'''
         if self.log_caller:


### PR DESCRIPTION
屏蔽了host端的所有乱print
后续优化perf框架时，也可以直接print，不会产生任何实际效果
通过logger.info/debug/error/warning的可以正常输出
container内的print（重定向到ranki.out.log的那些）不会受到任何影响