### PR TITLE
fix  prepare_in_container

### DIFF
--- a/training/run_benchmarks/prepare_in_container.py
+++ b/training/run_benchmarks/prepare_in_container.py
@@ -38,8 +38,10 @@ def parse_args():
 
 def install_requriements(vendor, model, framework, pipsource):
     '''Install required python packages in vendor's path.'''
+    # framework: DL framework, may include version info. e.g. pytorch_1.13
+    framework_name = framework.split("_")[0]
     vend_path = os.path.abspath(os.path.join(CURR_PATH, "../" + vendor))
-    vend_model_path = os.path.join(vend_path, model + "-" + framework)
+    vend_model_path = os.path.join(vend_path, model + "-" + framework_name)
     model_config_path = os.path.join(vend_model_path, "config/")
     req_file = os.path.join(model_config_path, "requirements.txt")
     env_file = os.path.join(model_config_path, "environment_variables.sh")
@@ -58,7 +60,9 @@ def install_requriements(vendor, model, framework, pipsource):
 def install_extensions(vendor, model, framework):
     '''Install vendor's extensions with setup.py script.'''
     vend_path = os.path.abspath(os.path.join(CURR_PATH, "../" + vendor))
-    vend_model_path = os.path.join(vend_path, model + "-" + framework)
+    # framework: DL framework, may include version info. e.g. pytorch_1.13
+    framework_name = framework.split("_")[0]
+    vend_model_path = os.path.join(vend_path, model + "-" + framework_name)
     source_path = os.path.join(vend_model_path, "csrc")
     model_config_path = os.path.join(vend_model_path, "config/")
     env_file = os.path.join(model_config_path, "environment_variables.sh")


### PR DESCRIPTION
![image](https://github.com/FlagOpen/FlagPerf/assets/10068952/0c05a0ed-cbce-4380-bb25-4e66b107d2b8)


而 \<vendor\>/\<model\>-\<framework\> 路径中不包含框架版本信息，如果这里不修改，会导致
找不到对应的路径，使得requirements.txt和extention无法正确安装，而retcode是0，继续往下执行start_\<framework\>_task.sh

截图如下：
![image](https://github.com/FlagOpen/FlagPerf/assets/10068952/00d811f8-3d9b-446f-8c00-730c8ac2dbfe)


最终，case会因缺少依赖而异常停止执行。

![image](https://github.com/FlagOpen/FlagPerf/assets/10068952/1f544393-3ecd-4a5e-a2f2-2862791ae4d9)
