### PR TITLE
fix faster-rcnn for 1x1

### DIFF
--- a/training/benchmarks/faster_rcnn/pytorch/run_pretraining.py
+++ b/training/benchmarks/faster_rcnn/pytorch/run_pretraining.py
@@ -41,6 +41,7 @@ def main() -> Tuple[Any, Any]:
     dist_pytorch.init_dist_training_env(config)
     dist_pytorch.barrier(config.vendor)
     model_driver.event(Event.INIT_START)
+    config.distributed = dist_pytorch.get_world_size() > 1
 
     # logger
     logger = model_driver.logger


### PR DESCRIPTION
修改前
![image](https://github.com/FlagOpen/FlagPerf/assets/10068952/fb3f0e71-046c-4234-86d0-4da1386a2de2)

修改后
![image](https://github.com/FlagOpen/FlagPerf/assets/10068952/06af21f5-14f5-4773-9c3e-31412384182b)

