### PR TITLE
修复bert 1x1下的时间统计bug

### DIFF
--- a/training/kunlunxin/bert-pytorch/extern/trainer_adapter.py
+++ b/training/kunlunxin/bert-pytorch/extern/trainer_adapter.py
@@ -7,8 +7,9 @@ import torch.distributed as dist
 from torch.cuda.amp import GradScaler
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.optim import Optimizer
-from torch_xmlir.optimizer import FusedLAMB
 
+import torch_xmlir
+from torch_xmlir.optimizer import FusedLAMB
 import torch_xmlir.core.xpu_model as xm
 
 import utils
@@ -62,7 +63,7 @@ def backward(step: int,
              optimizer: Optimizer,
              grad_scaler: GradScaler = None):
     loss.backward()
-
+    torch_xmlir.xpu.xpu_synchronize()
     update_step = step % config.gradient_accumulation_steps == 0
     if update_step:
         update_model_params(loss, optimizer, grad_scaler)


### PR DESCRIPTION
因为卡上的算子执行是异步的，在统计1x1的反向时间时需要显示地计算执行同步，否则反向的时间会不准确（比实际偏小）。1x8和2x8的场景下由于需要进行通信，通信过程会执行同步，因而没有上述问题。