### PR TITLE
Fix resnet50 evaluation

### DIFF
--- a/training/benchmarks/resnet50/pytorch/train/trainer.py
+++ b/training/benchmarks/resnet50/pytorch/train/trainer.py
@@ -126,6 +126,7 @@ class Trainer:
 
     @torch.no_grad()
     def evaluate(self, model, data_loader, device):
+        model.eval()
         acc1_total = 0.0
         steps = 0
         for step, batch in enumerate(data_loader):


### PR DESCRIPTION
@torch.no_grad()和model.eval()并不等价，模型处于训练模式还是推理模式可通过model.training变量来判断，以下例子可以说明：

```python
import torch

class MyModel(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.norm = torch.nn.BatchNorm2d(5)

    def forward(self, x):
        print('Training model: ' + str(self.training))
        out = self.norm(x)
        return out

@torch.no_grad()
def my_func(model, input):
    x = model(input)

@torch.no_grad()
def my_func_with_eval_mode(model, input):
    model.eval()
    x = model(input)

if __name__ == '__main__':
    torch.manual_seed(42)
    x = torch.randn(2, 5, 2, 2)

    model = MyModel()

    print('case1:')
    my_func(model, x)
    print()

    print('case2:')
    my_func_with_eval_mode(model, x)
    print()
```

结果：
```
> python test.py
case1:
Training model: True

case2:
Training model: False
```


某些module在推理模式和训练模式的计算会不同，例如BatchNorm和Dropout。

Resnet50模型的BatchNorm在train模式和eval模式的计算是不同的，简单来说，训练模式使用的是saved_mean和saved_var做计算，推理模式使用的是running_mean和running_var进行计算，可参考源码：
- https://github.com/pytorch/pytorch/blob/v1.8.2/torch/nn/modules/batchnorm.py#L120-L124
- https://github.com/pytorch/pytorch/blob/v1.8.2/aten/src/ATen/native/Normalization.cpp#L194-L199

