### PR TITLE
[workflow][kunlunxin] add klx training pre-pr-check workflow

### DIFF
--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -39,7 +39,7 @@ jobs:
       # TODO: run.py should return error code while the training is failed
       - name: Run test
         run: |
-          pushd &&
+          pushd training &&
           python3 run_benchmarks/run.py &&
           popd
       - name: Restore test_conf.py and cluster_conf.py

--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -15,6 +15,16 @@ on:
         description: 'value of PIP_SOURCE in test_conf.py'
         default: 'https://pypi.tuna.tsinghua.edu.cn/simple'
         required: true
+      max_epoch:
+        description: 'value of max_epoch in config.py'
+        type: number
+        default: 1
+        required: true
+      max_samples_termination:
+        description: 'value of max_samples_termination in config.py'
+        type: number
+        default: 10
+        required: true
 jobs:
   run-klx-training-test:
     runs-on: [ self-hosted, klx, r480 ]
@@ -35,13 +45,13 @@ jobs:
       # 2. Create tmp directory
       - name: 2.1 Retrieve the current timestamp
         id: work-timestamp
-        run: echo "WORK_TIMESTAMP=$(date +"%Y-%m%d-%H%M%S")"  >> "$GITHUB_OUTPUT"
+        run: echo "WORK_TIMESTAMP=$(date +"%Y%m%d%H%M%S")"  >> "$GITHUB_OUTPUT"
 
       - name: 2.2 Set work directory variable
         id: work-directory
         env:
           WORK_TIMESTAMP: ${{ steps.work-timestamp.outputs.WORK_TIMESTAMP }}
-        run: echo "WORK_DIRECTORY=$(realpath ${PWD}/..)/FlagPerf-$WORK_TIMESTAMP"  >> "$GITHUB_OUTPUT"
+        run: echo "WORK_DIRECTORY=$(realpath ${PWD}/..)/FlagPerf$WORK_TIMESTAMP"  >> "$GITHUB_OUTPUT"
 
       - name: 2.3 Create work directory and copy the whole directory
         env:
@@ -109,8 +119,8 @@ jobs:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
           MODEL_NAME: ${{ steps.get-model-name.outputs.MODEL_NAME }}
         run: |
-          echo "max_epoch = 1" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x1.py &&
-          echo "max_samples_termination = 20" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x1.py &&
+          echo "max_epoch = ${{ inputs.max_epoch }}" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x1.py &&
+          echo "max_samples_termination = ${{ inputs.max_samples_termination }}" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x1.py &&
           cat ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x1.py
 
       # 4.4 Setup config_R300x1x8.py
@@ -120,8 +130,8 @@ jobs:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
           MODEL_NAME: ${{ steps.get-model-name.outputs.MODEL_NAME }}
         run: |
-          echo "max_epoch = 1" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x8.py &&
-          echo "max_samples_termination = 20" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x8.py &&
+          echo "max_epoch = ${{ inputs.max_epoch }}" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x8.py &&
+          echo "max_samples_termination = ${{ inputs.max_samples_termination }}" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x8.py &&
           cat ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x8.py
 
       # 5. Setup cluster_conf.py(set random master port between 25000 and 26000)
@@ -133,8 +143,8 @@ jobs:
           echo "MASTER_PORT = '$(shuf -i 25000-26000 -n 1)'" >> ${WORK_DIRECTORY}/training/run_benchmarks/config/cluster_conf.py &&
           cat ${WORK_DIRECTORY}/training/run_benchmarks/config/cluster_conf.py
 
-      # 6.1 Generate VERSION for run.py
-      - name: 6.1 Generate VERSION for run.py
+      # 6.1 Modify VERSION in run.py
+      - name: 6.1 Modify VERSION in run.py
         env:
           WORK_TIMESTAMP: ${{ steps.work-timestamp.outputs.WORK_TIMESTAMP }}
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
@@ -145,8 +155,45 @@ jobs:
           sed -i "${SED_PATTERN}" ${WORK_DIRECTORY}/training/run_benchmarks/run.py &&
           echo "IMAGE_NAME=flagperf-kunlunxin-pytorch:t_v0.1_${MODEL_NAME}_${WORK_TIMESTAMP}"
 
-      # 6.2 Run test
-      - name: 6.2 Run test
+      # 6.2 Get run result name
+      # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
+      - name: 6.2 Get run result name
+        id: run-result-name
+        env:
+          WORK_TIMESTAMP: ${{ steps.work-timestamp.outputs.WORK_TIMESTAMP }}
+        run: echo "RUN_RESULT_NAME=run${WORK_TIMESTAMP}" >> "$GITHUB_OUTPUT"
+
+      # 6.3 Modify timestamp in run.py
+      - name: 6.3 Modify timestamp in run.py
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+          RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
+        run: |
+          export SED_PATTERN="s/timestamp_log_dir = \"run\" \+ time\.strftime\(\"%Y%m%d%H%M%S\", time\.localtime\(\)\)/timestamp_log_dir = \"${RUN_RESULT_NAME}\"/g" &&
+          echo "SED_PATTERN=${SED_PATTERN}" &&
+          sed -i "${SED_PATTERN}" ${WORK_DIRECTORY}/training/run_benchmarks/run.py &&
+          echo "timestamp_log_dir=${RUN_RESULT_NAME}"
+
+      # 6.4 Create 1x1 result path
+      - name: 6.4 Create 1x1 result path
+        if: ${{ inputs.case1x1 != '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+          RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
+        run: |
+          mkdir -p "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/"
+
+      # 6.5 Create 1x8 result path
+      - name: 6.5 Create 1x8 result path
+        if: ${{ inputs.case1x8 != '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+          RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
+        run: |
+          mkdir -p "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/"
+
+      # 6.6 Run test
+      - name: 6.6 Run test
         env:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
         run: |
@@ -155,14 +202,7 @@ jobs:
           popd
 
       # 7. Verify test result
-      # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
-      - name: 7.1 Get run result name
-        id: run-result-name
-        env:
-          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
-        run: echo "RUN_RESULT_NAME=$(cat ${WORK_DIRECTORY}/training/tmp_run.log | grep 'Initialize logger with log path:' | egrep -o 'run[0-9]+')"  >> "$GITHUB_OUTPUT"
-
-      - name: 7.2 Verify 1x1 case result
+      - name: 7.1 Verify 1x1 case result
         if: ${{ inputs.case1x1 != '' }}
         env:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
@@ -171,7 +211,7 @@ jobs:
           echo "LOG_FILEPATH=${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/rank0.out.log" &&
           grep '"event": "FINISHED"' "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/rank0.out.log"
 
-      - name: 7.3 Verify 1x8 case result
+      - name: 7.2 Verify 1x8 case result
         if: ${{ inputs.case1x8 != '' }}
         env:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
@@ -180,8 +220,26 @@ jobs:
           echo "LOG_FILEPATH=${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/rank0.out.log" &&
           grep '"event": "FINISHED"' "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/rank0.out.log"
 
-      # 8. Remove training container and image
-      - name: 8. Remove training container and image
+      # 8.1 Fetch kunlunxin_monitor result
+      - name: 8.1 Fetch 1x1 kunlunxin_monitor result
+        if: ${{ inputs.case1x1 != '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+          RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
+        run: |
+          cat "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/kunlunxin_monitor.log" || true
+
+      # 8.2 Fetch kunlunxin_monitor result
+      - name: 8.2 Fetch 1x1 kunlunxin_monitor result
+        if: ${{ inputs.case1x8 != '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+          RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
+        run: |
+          cat "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/kunlunxin_monitor.log" || true
+
+      # 9. Remove training container and image
+      - name: 9. Remove training container and image
         if: ${{ always() && (inputs.case1x1 != '' || inputs.case1x8 != '' )}}
         env:
           WORK_TIMESTAMP: ${{ steps.work-timestamp.outputs.WORK_TIMESTAMP }}

--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -85,7 +85,7 @@ jobs:
         env:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
         run: |
-          echo "CASES = { '${{ inputs.case1x1 }}' : '${{ inputs.dataset_path }}' }" >> ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py &&
+          echo "CASES = { '${{ inputs.case1x8 }}' : '${{ inputs.dataset_path }}' }" >> ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py &&
           cat ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py
       - name: 4.4 Setup empty cases in test_conf.py
         if: ${{ inputs.case1x1 == '' && inputs.case1x8 == '' }}

--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -30,6 +30,7 @@ jobs:
           echo "ACCE_VISIBLE_DEVICE_ENV_NAME = 'XPU_VISIBLE_DEVICES'" >> training/run_benchmarks/config/test_conf.py &&
           echo "PIP_SOURCE = 'https://pypi.tuna.tsinghua.edu.cn/simple'" &&
           echo "FLAGPERF_PATH = '${PWD}/training'" >> training/run_benchmarks/config/test_conf.py &&
+          echo "FLAGPERF_LOG_PATH = '${PWD}/training/results/'" >> training/run_benchmarks/config/test_conf.py &&
           echo "CASES = {'${{ inputs.case1x1 }}' : '${{ inputs.dataset_path }}', '${{ inputs.case1x8 }}' : '${{ inputs.dataset_path }}' }" >> training/run_benchmarks/config/test_conf.py &&
           cat training/run_benchmarks/config/test_conf.py
       - name: Setup cluster_conf.py

--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -172,10 +172,11 @@ jobs:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
           RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
         run: |
-          export SED_PATTERN="s/timestamp_log_dir = \"run\" \+ time\.strftime\(\"%Y%m%d%H%M%S\", time\.localtime\(\)\)/timestamp_log_dir = \"${RUN_RESULT_NAME}\"/g" &&
+          export SED_PATTERN="s/timestamp_log_dir = \"run\" + time.strftime(\"%Y%m%d%H%M%S\", time.localtime())/timestamp_log_dir = \"${RUN_RESULT_NAME}\"/g" &&
           echo "SED_PATTERN=${SED_PATTERN}" &&
           sed -i "${SED_PATTERN}" ${WORK_DIRECTORY}/training/run_benchmarks/run.py &&
-          echo "timestamp_log_dir=${RUN_RESULT_NAME}"
+          echo "timestamp_log_dir=${RUN_RESULT_NAME}" &&
+          grep ${RUN_RESULT_NAME} ${WORK_DIRECTORY}/training/run_benchmarks/run.py
 
       # 6.4 Create 1x1 result path
       - name: 6.4 Create 1x1 result path

--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -55,7 +55,7 @@ jobs:
           echo "VENDOR = 'kunlunxin'" >> ${TEST_CONF_FILEPATH} &&
           echo "ACCE_CONTAINER_OPT = '--device=/dev/xpu0 --device=/dev/xpu1 --device=/dev/xpu2 --device=/dev/xpu3 --device=/dev/xpu4 --device=/dev/xpu5 --device=/dev/xpu6 --device=/dev/xpu7 --device=/dev/xpuctrl'" >> ${TEST_CONF_FILEPATH} &&
           echo "ACCE_VISIBLE_DEVICE_ENV_NAME = 'XPU_VISIBLE_DEVICES'" >> ${TEST_CONF_FILEPATH} &&
-          echo "PIP_SOURCE = 'https://pypi.tuna.tsinghua.edu.cn/simple'" &&
+          echo "PIP_SOURCE = 'https://pypi.tuna.tsinghua.edu.cn/simple'" >> ${TEST_CONF_FILEPATH} &&
           echo "FLAGPERF_PATH = '${WORK_DIRECTORY}/training'" >> ${TEST_CONF_FILEPATH} &&
           echo "FLAGPERF_LOG_PATH = '${WORK_DIRECTORY}/training/result/'" >> ${TEST_CONF_FILEPATH} &&
           cat ${TEST_CONF_FILEPATH}

--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -5,13 +5,11 @@ on:
   workflow_dispatch:
     inputs:
       case1x1:
-        description: '1x1 case name that filled into test_conf.py'
+        description: '1x1 case name that filled into test_conf.py (empty means not to execute)'
         default: 'model:framework:hardwareID:1:1:1'
-        required: true
       case1x8:
-        description: '1x8 case name that filled into test_conf.py'
+        description: '1x8 case name that filled into test_conf.py (empty means not to execute)'
         default: 'model:framework:hardwareID:1:8:1'
-        required: true
       dataset_path:
         description: 'dataset path filled into test_conf.py'
         default: 'dataset path'
@@ -20,10 +18,13 @@ jobs:
   run-klx-training-test:
     runs-on: [ self-hosted, klx, r480 ]
     steps:
+      # 1. Checkout
       - name: Checkout code
         uses: actions/checkout@master
         with:
           fetch-depth: 1
+
+      # 2. Setup basic information in test_conf.py
       - name: Setup test_conf.py
         run: |
           echo "VENDOR = 'kunlunxin'" >> training/run_benchmarks/config/test_conf.py &&
@@ -32,19 +33,68 @@ jobs:
           echo "PIP_SOURCE = 'https://pypi.tuna.tsinghua.edu.cn/simple'" &&
           echo "FLAGPERF_PATH = '${PWD}/training'" >> training/run_benchmarks/config/test_conf.py &&
           echo "FLAGPERF_LOG_PATH = '${PWD}/training/result/'" >> training/run_benchmarks/config/test_conf.py &&
-          echo "CASES = {'${{ inputs.case1x1 }}' : '${{ inputs.dataset_path }}', '${{ inputs.case1x8 }}' : '${{ inputs.dataset_path }}' }" >> training/run_benchmarks/config/test_conf.py &&
           cat training/run_benchmarks/config/test_conf.py
+
+      # 3. Setup cases in test_conf.py
+      - name: Setup 1x1 case and 1x8 case in test_conf.py
+        if: ${{ inputs.case1x1 != '' && inputs.case1x8 != '' }}
+        run: |
+          echo "CASES = { '${{ inputs.case1x1 }}' : '${{ inputs.dataset_path }}', '${{ inputs.case1x8 }}' : '${{ inputs.dataset_path }}' }" >> training/run_benchmarks/config/test_conf.py &&
+          cat training/run_benchmarks/config/test_conf.py
+      - name: Setup 1x1 case in test_conf.py
+        if: ${{ inputs.case1x1 != '' && inputs.case1x8 == '' }}
+        run: |
+          echo "CASES = { '${{ inputs.case1x1 }}' : '${{ inputs.dataset_path }}' }" >> training/run_benchmarks/config/test_conf.py &&
+          cat training/run_benchmarks/config/test_conf.py
+      - name: Setup 1x8 case in test_conf.py
+        if: ${{ inputs.case1x1 == '' && inputs.case1x8 != '' }}
+        run: |
+          echo "CASES = { '${{ inputs.case1x1 }}' : '${{ inputs.dataset_path }}' }" >> training/run_benchmarks/config/test_conf.py &&
+          cat training/run_benchmarks/config/test_conf.py
+      - name: Setup empty cases in test_conf.py
+        if: ${{ inputs.case1x1 == '' && inputs.case1x8 == '' }}
+        run: |
+          echo "At least one of case1x1 and case1x8 is not empty！" &&
+          ls non_existent_file.txt
+
+      # 4. Setup cluster_conf.py
       - name: Setup cluster_conf.py
         run: |
           echo "HOSTS = ['127.0.0.1']" >> training/run_benchmarks/config/cluster_conf.py &&
           cat training/run_benchmarks/config/cluster_conf.py
-      # TODO: run.py should return error code while the training is failed
+
+      # 5. Run test
       - name: Run test
         run: |
           pushd training &&
-          python3 run_benchmarks/run.py &&
+          python3 run_benchmarks/run.py 2>&1 | tee tmp_run.log &&
           popd
-      - name: Restore test_conf.py and cluster_conf.py
+
+      # 6. Verify test result
+      # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
+      - name: Get run result name
+        id: run-result-name
+        run: echo "RUN_RESULT_NAME=$(cat training/tmp_run.log | grep 'Initialize logger with log path:' | egrep -o 'run[0-9]+')"  >> "$GITHUB_OUTPUT"
+
+      - name: Verify 1x1 case result
+        if: ${{ inputs.case1x1 != '' }}
+        env:
+          RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
         run: |
+          cat training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 != '' }}/round1/127.0.0.1_noderank0/rank0.out.log
+          grep "FINISHED" "training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 != '' }}/round1/127.0.0.1_noderank0/rank0.out.log"
+
+      - name: Verify 1x8 case result
+        if: ${{ inputs.case1x8 != '' }}
+        env:
+          RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
+        run: |
+          cat training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 != '' }}/round1/127.0.0.1_noderank0/rank0.out.log
+          grep "FINISHED" "training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 != '' }}/round1/127.0.0.1_noderank0/rank0.out.log"
+
+      # 7. Clean job
+      - name: Remove tmp_run.log, restore test_conf.py and cluster_conf.py
+        run: |
+          rm -f training/tmp_run.log &&
           git checkout training/run_benchmarks/config/test_conf.py &&
           git checkout training/run_benchmarks/config/cluster_conf.py

--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -129,7 +129,7 @@ jobs:
           cat ${WORK_DIRECTORY}/training/run_benchmarks/config/cluster_conf.py
 
       # 6.1 Generate VERSION for run.py
-      - name: 6.2 Generate VERSION for run.py
+      - name: 6.1 Generate VERSION for run.py
         env:
           WORK_TIMESTAMP: ${{ steps.work-timestamp.outputs.WORK_TIMESTAMP }}
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
@@ -141,7 +141,7 @@ jobs:
           echo "IMAGE_NAME=flagperf-kunlunxin-pytorch:t_v0.1_${MODEL_NAME}_${WORK_TIMESTAMP}"
 
       # 6.2 Run test
-      - name: 6.3 Run test
+      - name: 6.2 Run test
         env:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
         run: |

--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -16,12 +16,12 @@ on:
         default: 'https://pypi.tuna.tsinghua.edu.cn/simple'
         required: true
       max_epoch:
-        description: 'value of max_epoch in config.py'
+        description: 'value of max_epoch in config_R300_xxx.py'
         type: number
         default: 1
         required: true
       max_samples_termination:
-        description: 'value of max_samples_termination in config.py'
+        description: 'value of max_samples_termination in config_R300_xxx.py'
         type: number
         default: 10
         required: true
@@ -29,8 +29,8 @@ jobs:
   run-klx-training-test:
     runs-on: [ self-hosted, klx, r480 ]
     steps:
-      # 0. Display inputs
-      - name: 0. Display inputs
+      # 0.1 Display inputs
+      - name: 0.1 Display inputs
         run: |
           echo "case1x1=${{ inputs.case1x1 }}" &&
           echo "case1x8=${{ inputs.case1x8 }}" &&
@@ -38,6 +38,17 @@ jobs:
           echo "pip_source=${{ inputs.pip_source }}" &&
           echo "max_epoch=${{ inputs.max_epoch }}" &&
           echo "max_samples_termination=${{ inputs.max_samples_termination }}"
+
+      # 0.2 Verify inputs
+      - name: 0.2 Verify inputs
+        run: |
+          export CASE1x1="${{ inputs.case1x1 }}" && export CASE1x8="${{ inputs.case1x1 }}" &&
+          echo "Verifying case1x1..." && echo "${CASE1x1:-model:framework:hardwareID:1:1:1}" | egrep "^[0-9a-zA-Z_\-]+:[0-9a-zA-Z_\-\.]+:[0-9a-zA-Z_\-\.]+:1:1:1$" > /dev/null && echo "success!" &&
+          echo "Verifying case1x8..." && echo "${CASE1x8:-model:framework:hardwareID:1:8:1}" | egrep "^[0-9a-zA-Z_\-]+:[0-9a-zA-Z_\-\.]+:[0-9a-zA-Z_\-\.]+:1:8:1$" > /dev/null && echo "success!" &&
+          echo "Verifying dataset_path..." && echo "${{ inputs.dataset_path }}" | egrep "^([0-9a-zA-Z\/\._\-\:]+)$" > /dev/null && echo "success!" &&
+          echo "Verifying pip_source..." && echo "${{ inputs.pip_source }}" | egrep "^((https:\/\/)|(http:\/\/))?(www\.)?[a-zA-Z0-9\.\/]+$" > /dev/null && echo "success!" &&
+          echo "Verifying max_epoch..." && echo "${{ inputs.max_epoch }}" | egrep "^[0-9]+$" > /dev/null && echo "success!" &&
+          echo "Verifying max_samples_termination..." && echo "${{ inputs.max_samples_termination }}" | egrep "^[0-9]+$" > /dev/null && echo "success!"
 
       # 1. Checkout
       - name: 1. Checkout code

--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -1,0 +1,48 @@
+name: klx-training-pre-pr-check
+
+on:
+  workflow_dispatch:
+    inputs:
+      case1x1:
+        description: '1x1 case name that filled into test_conf.py'
+        default: 'model:framework:hardwareID:1:1:1'
+        required: true
+      case1x8:
+        description: '1x8 case name that filled into test_conf.py'
+        default: 'model:framework:hardwareID:1:8:1'
+        required: true
+      dataset_path:
+        description: 'dataset path filled into test_conf.py'
+        default: 'dataset path'
+        required: true
+jobs:
+  run-klx-training-test:
+    runs-on: [ self-hosted, klx, r480 ]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 1
+      - name: Setup test_conf.py
+        run: |
+          echo "VENDOR = 'kunlunxin'" >> training/run_benchmarks/config/test_conf.py &&
+          echo "ACCE_CONTAINER_OPT = '--device=/dev/xpu0 --device=/dev/xpu1 --device=/dev/xpu2 --device=/dev/xpu3 --device=/dev/xpu4 --device=/dev/xpu5 --device=/dev/xpu6 --device=/dev/xpu7 --device=/dev/xpuctrl'" >> training/run_benchmarks/config/test_conf.py &&
+          echo "ACCE_VISIBLE_DEVICE_ENV_NAME = 'XPU_VISIBLE_DEVICES'" >> training/run_benchmarks/config/test_conf.py &&
+          echo "PIP_SOURCE = 'https://pypi.tuna.tsinghua.edu.cn/simple'" &&
+          echo "FLAGPERF_PATH = '${PWD}/training'" >> training/run_benchmarks/config/test_conf.py &&
+          echo "CASES = {'${{ inputs.case1x1 }}' : '${{ inputs.dataset_path }}', '${{ inputs.case1x8 }}' : '${{ inputs.dataset_path }}' }" >> training/run_benchmarks/config/test_conf.py &&
+          cat training/run_benchmarks/config/test_conf.py
+      - name: Setup cluster_conf.py
+        run: |
+          echo "HOSTS = ['127.0.0.1']" >> training/run_benchmarks/config/cluster_conf.py &&
+          cat training/run_benchmarks/config/cluster_conf.py
+      # TODO: run.py should return error code while the training is failed
+      - name: Run test
+        run: |
+          pushd &&
+          python3 run_benchmarks/run.py &&
+          popd
+      - name: Restore test_conf.py and cluster_conf.py
+        run: |
+          git checkout training/run_benchmarks/config/test_conf.py &&
+          git checkout training/run_benchmarks/config/cluster_conf.py

--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -120,12 +120,13 @@ jobs:
           echo "max_samples_termination = 20" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x8.py &&
           cat ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x8.py
 
-      # 5. Setup cluster_conf.py
-      - name: 5. Setup cluster_conf.py
+      # 5. Setup cluster_conf.py(set random master port between 25000 and 26000)
+      - name: 5. Setup cluster_conf.py(set random master port between 25000 and 26000)
         env:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
         run: |
           echo "HOSTS = ['127.0.0.1']" >> ${WORK_DIRECTORY}/training/run_benchmarks/config/cluster_conf.py &&
+          echo "MASTER_PORT = '$(shuf -i 25000-26000 -n 1)'" >> ${WORK_DIRECTORY}/training/run_benchmarks/config/cluster_conf.py &&
           cat ${WORK_DIRECTORY}/training/run_benchmarks/config/cluster_conf.py
 
       # 6.1 Generate VERSION for run.py

--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -2,53 +2,72 @@
 name: klx-training-pre-pr-check
 
 on:
-  workflow_dispatch:
-    inputs:
-      case1x1:
-        description: 'e.g. model:framework:hardwareID:1:1:1 (empty means not to execute)'
-      case1x8:
-        description: 'e.g. model:framework:hardwareID:1:8:1 (empty means not to execute)'
-      dataset_path:
-        description: 'dataset path filled into test_conf.py'
-        required: true
-      pip_source:
-        description: 'value of PIP_SOURCE in test_conf.py'
-        default: 'https://pypi.tuna.tsinghua.edu.cn/simple'
-        required: true
-      max_epoch:
-        description: 'value of max_epoch in config_R300_xxx.py'
-        type: number
-        default: 1
-        required: true
-      max_samples_termination:
-        description: 'value of max_samples_termination in config_R300_xxx.py'
-        type: number
-        default: 10
-        required: true
+  pull_request:
+    branches: [ "main", "master" ]
 jobs:
   run-klx-training-test:
+    if:  ${{ startsWith(github.event.pull_request.title, '[kunlunxin]') || startsWith(github.event.pull_request.title, '[klx]') }}
     runs-on: [ self-hosted, klx, r480 ]
     steps:
-      # 0.1 Display inputs
-      - name: 0.1 Display inputs
+      # 0.1 Extract inputs
+      - name: 0.1 Extract inputs (The pull request title should be like "[kunlunxin][MODEL_NAME][DATASET_PATH] xxxxxxx")
+        id: extract-inputs
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          echo "case1x1=${{ inputs.case1x1 }}" &&
-          echo "case1x8=${{ inputs.case1x8 }}" &&
-          echo "dataset_path=${{ inputs.dataset_path }}" &&
-          echo "pip_source=${{ inputs.pip_source }}" &&
-          echo "max_epoch=${{ inputs.max_epoch }}" &&
-          echo "max_samples_termination=${{ inputs.max_samples_termination }}"
+          echo "github.event.pull_request.title:" && echo ${PR_TITLE} &&
+          echo "github.event.pull_request.body:" && echo ${PR_BODY} &&
+          echo "${PR_TITLE}" | egrep "^\[kunlunxin\]\[[0-9a-zA-Z_\-]+\]\[[0-9a-zA-Z\/\._\-\:]+\].*$" &&
+          export "MODEL_NAME=$(echo ${PR_TITLE} | awk -F '[][]' '{print $4}')" &&
+          export "DATASET_PATH=$(echo ${PR_TITLE} | awk -F '[][]' '{print $6}')" &&
+          export "CASE1x1=${MODEL_NAME}:pytorch:R300:1:1:1" &&
+          export "CASE1x8=${MODEL_NAME}:pytorch:R300:1:8:1" &&
+          export "PIP_SOURCE=$(echo ${PR_BODY} | grep 'PIP_SOURCE=' | head -n 1 | sed 's/PIP_SOURCE=//g')" &&
+          export "MAX_EPOCH=$(echo ${PR_BODY} | grep 'MAX_EPOCH=' | head -n 1 | sed 's/MAX_EPOCH=//g')" &&
+          export "MAX_SAMPLES_TERMINATION=$(echo ${PR_BODY} | grep 'MAX_SAMPLES_TERMINATION=' | head -n 1 | sed 's/MAX_SAMPLES_TERMINATION=//g')" &&
+          echo "MODEL_NAME=${MODEL_NAME}" && echo "MODEL_NAME=${MODEL_NAME}" >> "$GITHUB_OUTPUT" &&
+          echo "DATASET_PATH=${DATASET_PATH}" && echo "DATASET_PATH=${DATASET_PATH}" >> "$GITHUB_OUTPUT" &&
+          echo "CASE1x1=${CASE1x1}" && echo "CASE1x1=${CASE1x1}" >> "$GITHUB_OUTPUT" &&
+          echo "CASE1x8=${CASE1x8}" && echo "CASE1x8=${CASE1x8}" >> "$GITHUB_OUTPUT" &&
+          echo "PIP_SOURCE=${PIP_SOURCE:-https://pypi.tuna.tsinghua.edu.cn/simple}" && echo "PIP_SOURCE=${PIP_SOURCE:-https://pypi.tuna.tsinghua.edu.cn/simple}" >> "$GITHUB_OUTPUT" &&
+          echo "MAX_EPOCH=${MAX_EPOCH:-1}" && echo "MAX_EPOCH=${MAX_EPOCH:-1}" >> "$GITHUB_OUTPUT" &&
+          echo "MAX_SAMPLES_TERMINATION=${MAX_SAMPLES_TERMINATION:-10}" && echo "MAX_SAMPLES_TERMINATION=${MAX_SAMPLES_TERMINATION:-10}" >> "$GITHUB_OUTPUT"
 
-      # 0.2 Verify inputs
-      - name: 0.2 Verify inputs
+      # 0.2 Display inputs
+      - name: 0.2 Display inputs
+        env:
+          CASE1x1: ${{ steps.extract-inputs.outputs.CASE1x1 }}
+          CASE1x8: ${{ steps.extract-inputs.outputs.CASE1x8 }}
+          DATASET_PATH: ${{ steps.extract-inputs.outputs.DATASET_PATH }}
+          PIP_SOURCE: ${{ steps.extract-inputs.outputs.PIP_SOURCE }}
+          MAX_EPOCH: ${{ steps.extract-inputs.outputs.MAX_EPOCH }}
+          MAX_SAMPLES_TERMINATION: ${{ steps.extract-inputs.outputs.MAX_SAMPLES_TERMINATION }}
         run: |
-          export CASE1x1="${{ inputs.case1x1 }}" && export CASE1x8="${{ inputs.case1x1 }}" &&
-          echo "Verifying case1x1..." && echo "${CASE1x1:-model:framework:hardwareID:1:1:1}" | egrep "^[0-9a-zA-Z_\-]+:[0-9a-zA-Z_\-\.]+:[0-9a-zA-Z_\-\.]+:1:1:1$" > /dev/null && echo "success!" &&
-          echo "Verifying case1x8..." && echo "${CASE1x8:-model:framework:hardwareID:1:8:1}" | egrep "^[0-9a-zA-Z_\-]+:[0-9a-zA-Z_\-\.]+:[0-9a-zA-Z_\-\.]+:1:8:1$" > /dev/null && echo "success!" &&
-          echo "Verifying dataset_path..." && echo "${{ inputs.dataset_path }}" | egrep "^([0-9a-zA-Z\/\._\-\:]+)$" > /dev/null && echo "success!" &&
-          echo "Verifying pip_source..." && echo "${{ inputs.pip_source }}" | egrep "^((https:\/\/)|(http:\/\/))?(www\.)?[a-zA-Z0-9\.\/]+$" > /dev/null && echo "success!" &&
-          echo "Verifying max_epoch..." && echo "${{ inputs.max_epoch }}" | egrep "^[0-9]+$" > /dev/null && echo "success!" &&
-          echo "Verifying max_samples_termination..." && echo "${{ inputs.max_samples_termination }}" | egrep "^[0-9]+$" > /dev/null && echo "success!"
+          echo "case1x1=${CASE1x1}" &&
+          echo "case1x8=${CASE1x8}" &&
+          echo "dataset_path=${DATASET_PATH}" &&
+          echo "pip_source=${PIP_SOURCE}" &&
+          echo "max_epoch=${MAX_EPOCH}" &&
+          echo "max_samples_termination=${MAX_SAMPLES_TERMINATION}"
+
+      # 0.3 Verify inputs
+      - name: 0.3 Verify inputs
+        env:
+          CASE1x1: ${{ steps.extract-inputs.outputs.CASE1x1 }}
+          CASE1x8: ${{ steps.extract-inputs.outputs.CASE1x8 }}
+          DATASET_PATH: ${{ steps.extract-inputs.outputs.DATASET_PATH }}
+          PIP_SOURCE: ${{ steps.extract-inputs.outputs.PIP_SOURCE }}
+          MAX_EPOCH: ${{ steps.extract-inputs.outputs.MAX_EPOCH }}
+          MAX_SAMPLES_TERMINATION: ${{ steps.extract-inputs.outputs.MAX_SAMPLES_TERMINATION }}
+        run: |
+          export CASE1x1="${CASE1x1}" && export CASE1x8="${CASE1x8}" &&
+          echo "Verifying case1x1..." && echo "${CASE1x1}" | egrep "^[0-9a-zA-Z_\-]+:[0-9a-zA-Z_\-\.]+:[0-9a-zA-Z_\-\.]+:1:1:1$" > /dev/null && echo "success!" &&
+          echo "Verifying case1x8..." && echo "${CASE1x8}" | egrep "^[0-9a-zA-Z_\-]+:[0-9a-zA-Z_\-\.]+:[0-9a-zA-Z_\-\.]+:1:8:1$" > /dev/null && echo "success!" &&
+          echo "Verifying dataset_path..." && echo "${DATASET_PATH}" | egrep "^([0-9a-zA-Z\/\._\-\:]+)$" > /dev/null && echo "success!" &&
+          echo "Verifying pip_source..." && echo "${PIP_SOURCE}" | egrep "^((https:\/\/)|(http:\/\/))?(www\.)?[a-zA-Z0-9\.\/]+$" > /dev/null && echo "success!" &&
+          echo "Verifying max_epoch..." && echo "${MAX_EPOCH}" | egrep "^[0-9]+$" > /dev/null && echo "success!" &&
+          echo "Verifying max_samples_termination..." && echo "${MAX_SAMPLES_TERMINATION}" | egrep "^[0-9]+$" > /dev/null && echo "success!"
 
       # 1. Checkout
       - name: 1. Checkout code
@@ -77,76 +96,67 @@ jobs:
       # 3. Setup basic information in test_conf.py
       - name: 3. Setup test_conf.py
         env:
+          PIP_SOURCE: ${{ steps.extract-inputs.outputs.PIP_SOURCE }}
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
         run: |
           export TEST_CONF_FILEPATH=${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py
           echo "VENDOR = 'kunlunxin'" >> ${TEST_CONF_FILEPATH} &&
           echo "ACCE_CONTAINER_OPT = '--device=/dev/xpu0 --device=/dev/xpu1 --device=/dev/xpu2 --device=/dev/xpu3 --device=/dev/xpu4 --device=/dev/xpu5 --device=/dev/xpu6 --device=/dev/xpu7 --device=/dev/xpuctrl'" >> ${TEST_CONF_FILEPATH} &&
           echo "ACCE_VISIBLE_DEVICE_ENV_NAME = 'XPU_VISIBLE_DEVICES'" >> ${TEST_CONF_FILEPATH} &&
-          echo "PIP_SOURCE = '${{ inputs.pip_source }}'" >> ${TEST_CONF_FILEPATH} &&
+          echo "PIP_SOURCE = '${PIP_SOURCE}'" >> ${TEST_CONF_FILEPATH} &&
           echo "FLAGPERF_PATH = '${WORK_DIRECTORY}/training'" >> ${TEST_CONF_FILEPATH} &&
           echo "FLAGPERF_LOG_PATH = '${WORK_DIRECTORY}/training/result/'" >> ${TEST_CONF_FILEPATH} &&
           cat ${TEST_CONF_FILEPATH}
 
-      # 4.1 Get model name
-      - name: 4.1 Get model name
-        id: get-model-name
+      # 4.1 Setup cases in test_conf.py
+      - name: 4.1 Setup 1x1 case and 1x8 case in test_conf.py
+        env:
+          CASE1x1: ${{ steps.extract-inputs.outputs.CASE1x1 }}
+          CASE1x8: ${{ steps.extract-inputs.outputs.CASE1x8 }}
+          DATASET_PATH: ${{ steps.extract-inputs.outputs.DATASET_PATH }}
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
         run: |
-          export MODEL_NAME_1x1=$(echo '${{ inputs.case1x1 }}' | cut -d ':' -f1) &&
-          export MODEL_NAME_1x8=$(echo '${{ inputs.case1x8 }}' | cut -d ':' -f1) &&
-          echo "MODEL_NAME=${MODEL_NAME_1x1:-${MODEL_NAME_1x8}}"  >> "$GITHUB_OUTPUT"
+          echo "CASES = { '${CASE1x1}' : '${DATASET_PATH}', '${CASE1x8}' : '${DATASET_PATH}' }" >> ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py &&
+          cat ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py
 
-      # 4.2 Setup cases in test_conf.py
-      - name: 4.2 Setup 1x1 case and 1x8 case in test_conf.py
-        if: ${{ inputs.case1x1 != '' && inputs.case1x8 != '' }}
+      # 4.2 Setup config_R300x1x1.py
+      - name: 4.2 Setup config_R300x1x1.py
         env:
+          MAX_EPOCH: ${{ steps.extract-inputs.outputs.MAX_EPOCH }}
+          MAX_SAMPLES_TERMINATION: ${{ steps.extract-inputs.outputs.MAX_SAMPLES_TERMINATION }}
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+          MODEL_NAME: ${{ steps.extract-inputs.outputs.MODEL_NAME }}
         run: |
-          echo "CASES = { '${{ inputs.case1x1 }}' : '${{ inputs.dataset_path }}', '${{ inputs.case1x8 }}' : '${{ inputs.dataset_path }}' }" >> ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py &&
-          cat ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py
-      - name: 4.2 Setup 1x1 case in test_conf.py
-        if: ${{ inputs.case1x1 != '' && inputs.case1x8 == '' }}
-        env:
-          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
-        run: |
-          echo "CASES = { '${{ inputs.case1x1 }}' : '${{ inputs.dataset_path }}' }" >> ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py &&
-          cat ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py
-      - name: 4.3 Setup 1x8 case in test_conf.py
-        if: ${{ inputs.case1x1 == '' && inputs.case1x8 != '' }}
-        env:
-          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
-        run: |
-          echo "CASES = { '${{ inputs.case1x8 }}' : '${{ inputs.dataset_path }}' }" >> ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py &&
-          cat ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py
-      - name: 4.4 Setup empty cases in test_conf.py
-        if: ${{ inputs.case1x1 == '' && inputs.case1x8 == '' }}
-        env:
-          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
-        run: |
-          echo "At least one of case1x1 and case1x8 is not empty!" &&
-          ls non_existent_file.txt
-      
-      # 4.3 Setup config_R300x1x1.py
-      - name: 4.3 Setup config_R300x1x1.py
-        if: ${{ inputs.case1x1 != '' }}
-        env:
-          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
-          MODEL_NAME: ${{ steps.get-model-name.outputs.MODEL_NAME }}
-        run: |
-          echo "max_epoch = ${{ inputs.max_epoch }}" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x1.py &&
-          echo "max_samples_termination = ${{ inputs.max_samples_termination }}" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x1.py &&
+          ls ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x1.py &&
+          echo "max_epoch = ${MAX_EPOCH}" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x1.py &&
+          echo "max_samples_termination = ${MAX_SAMPLES_TERMINATION}" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x1.py &&
           cat ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x1.py
 
-      # 4.4 Setup config_R300x1x8.py
-      - name: 4.4 Setup config_R300x1x8.py
-        if: ${{ inputs.case1x8 != '' }}
+      # 4.3 Setup config_R300x1x8.py
+      - name: 4.3 Setup config_R300x1x8.py
         env:
+          MAX_EPOCH: ${{ steps.extract-inputs.outputs.MAX_EPOCH }}
+          MAX_SAMPLES_TERMINATION: ${{ steps.extract-inputs.outputs.MAX_SAMPLES_TERMINATION }}
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
-          MODEL_NAME: ${{ steps.get-model-name.outputs.MODEL_NAME }}
+          MODEL_NAME: ${{ steps.extract-inputs.outputs.MODEL_NAME }}
         run: |
-          echo "max_epoch = ${{ inputs.max_epoch }}" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x8.py &&
-          echo "max_samples_termination = ${{ inputs.max_samples_termination }}" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x8.py &&
+          ls ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x8.py &&
+          echo "max_epoch = ${MAX_EPOCH}" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x8.py &&
+          echo "max_samples_termination = ${MAX_SAMPLES_TERMINATION}" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x8.py &&
           cat ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x8.py
+
+      # 4.4 Setup config_R300x2x8.py
+      - name: 4.4 Setup config_R300x2x8.py (Check whether config_R300x2x8.py exists)
+        env:
+          MAX_EPOCH: ${{ steps.extract-inputs.outputs.MAX_EPOCH }}
+          MAX_SAMPLES_TERMINATION: ${{ steps.extract-inputs.outputs.MAX_SAMPLES_TERMINATION }}
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+          MODEL_NAME: ${{ steps.extract-inputs.outputs.MODEL_NAME }}
+        run: |
+          ls ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x2x8.py &&
+          echo "max_epoch = ${MAX_EPOCH}" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x2x8.py &&
+          echo "max_samples_termination = ${MAX_SAMPLES_TERMINATION}" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x2x8.py &&
+          cat ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x2x8.py
 
       # 5. Setup cluster_conf.py(set random master port between 25000 and 26000)
       - name: 5. Setup cluster_conf.py(set random master port between 25000 and 26000)
@@ -162,7 +172,7 @@ jobs:
         env:
           WORK_TIMESTAMP: ${{ steps.work-timestamp.outputs.WORK_TIMESTAMP }}
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
-          MODEL_NAME: ${{ steps.get-model-name.outputs.MODEL_NAME }}
+          MODEL_NAME: ${{ steps.extract-inputs.outputs.MODEL_NAME }}
         run: |
           export SED_PATTERN="s/VERSION = \"v0.1\"/VERSION = \"v0.1_${MODEL_NAME}_${WORK_TIMESTAMP}\"/g" &&
           echo "SED_PATTERN=${SED_PATTERN}" &&
@@ -191,22 +201,22 @@ jobs:
 
       # 6.4 Create 1x1 result path
       - name: 6.4 Create 1x1 result path
-        if: ${{ inputs.case1x1 != '' }}
         env:
+          CASE1x1: ${{ steps.extract-inputs.outputs.CASE1x1 }}
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
           RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
         run: |
-          mkdir -p "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/"
+          mkdir -p "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${CASE1x1}/round1/127.0.0.1_noderank0/"
 
       # 6.5 Create 1x8 result path
       - name: 6.5 Create 1x8 result path
-        if: ${{ inputs.case1x8 != '' }}
         env:
+          CASE1x8: ${{ steps.extract-inputs.outputs.CASE1x8 }}
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
           RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
         run: |
-          mkdir -p "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/"
-      
+          mkdir -p "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${CASE1x8}/round1/127.0.0.1_noderank0/"
+
       # 6.6 Modify xpu_monitor.pid in training/kunlunxin/kunlunxin_monitor.py
       - name: 6.6 Modify xpu_monitor.pid in training/kunlunxin/kunlunxin_monitor.py
         env:
@@ -230,40 +240,40 @@ jobs:
 
       # 7. Verify test result
       - name: 7.1 Verify 1x1 case result
-        if: ${{ inputs.case1x1 != '' }}
         env:
+          CASE1x1: ${{ steps.extract-inputs.outputs.CASE1x1 }}
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
           RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
         run: |
-          echo "LOG_FILEPATH=${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/rank0.out.log" &&
-          grep '"event": "FINISHED"' "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/rank0.out.log" > /dev/null
+          echo "LOG_FILEPATH=${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${CASE1x1}/round1/127.0.0.1_noderank0/rank0.out.log" &&
+          grep '"event": "FINISHED"' "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${CASE1x1}/round1/127.0.0.1_noderank0/rank0.out.log" > /dev/null
 
       - name: 7.2 Verify 1x8 case result
-        if: ${{ inputs.case1x8 != '' }}
         env:
+          CASE1x8: ${{ steps.extract-inputs.outputs.CASE1x8 }}
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
           RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
         run: |
-          echo "LOG_FILEPATH=${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/rank0.out.log" &&
-          grep '"event": "FINISHED"' "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/rank0.out.log" > /dev/null
+          echo "LOG_FILEPATH=${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${CASE1x8}/round1/127.0.0.1_noderank0/rank0.out.log" &&
+          grep '"event": "FINISHED"' "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${CASE1x8}/round1/127.0.0.1_noderank0/rank0.out.log" > /dev/null
 
       # 8.1 Fetch 1x1 kunlunxin_monitor result
       - name: 8.1 Fetch 1x1 kunlunxin_monitor result
-        if: ${{ inputs.case1x1 != '' }}
         env:
+          CASE1x1: ${{ steps.extract-inputs.outputs.CASE1x1 }}
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
           RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
         run: |
-          cat "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/kunlunxin_monitor.log" || true
-        
+          cat "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${CASE1x1}/round1/127.0.0.1_noderank0/kunlunxin_monitor.log" || true
+
       # 8.2 Get 1x1 kunlunxin_monitor max memory usage
       - name: 8.2 Get 1x1 kunlunxin_monitor max memory usage
-        if: ${{ inputs.case1x1 != '' }}
         env:
+          CASE1x1: ${{ steps.extract-inputs.outputs.CASE1x1 }}
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
           RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
         run: |
-          cat "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/kunlunxin_monitor.log" | \
+          cat "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${CASE1x1}/round1/127.0.0.1_noderank0/kunlunxin_monitor.log" | \
           grep 'MiB' | \
           awk '{ print $3 }' | \
           sed "s/MiB//g" | \
@@ -273,21 +283,21 @@ jobs:
 
       # 8.3 Fetch 1x8 kunlunxin_monitor result
       - name: 8.3 Fetch 1x8 kunlunxin_monitor result
-        if: ${{ inputs.case1x8 != '' }}
         env:
+          CASE1x8: ${{ steps.extract-inputs.outputs.CASE1x8 }}
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
           RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
         run: |
-          cat "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/kunlunxin_monitor.log" || true
+          cat "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${CASE1x8}/round1/127.0.0.1_noderank0/kunlunxin_monitor.log" || true
 
       # 8.4 Get 1x8 kunlunxin_monitor max memory usage
       - name: 8.4 Get 1x8 kunlunxin_monitor max memory usage
-        if: ${{ inputs.case1x8 != '' }}
         env:
+          CASE1x8: ${{ steps.extract-inputs.outputs.CASE1x8 }}
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
           RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
         run: |
-            cat "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/kunlunxin_monitor.log" | \
+            cat "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${CASE1x8}/round1/127.0.0.1_noderank0/kunlunxin_monitor.log" | \
             grep 'MiB' | \
             awk '{ print $3 }' | \
             sed "s/MiB//g" | \
@@ -297,10 +307,10 @@ jobs:
 
       # 9. Remove training container and image
       - name: 9. Remove training container and image
-        if: ${{ always() && (inputs.case1x1 != '' || inputs.case1x8 != '' )}}
+        if: ${{ always() }}
         env:
           WORK_TIMESTAMP: ${{ steps.work-timestamp.outputs.WORK_TIMESTAMP }}
-          MODEL_NAME: ${{ steps.get-model-name.outputs.MODEL_NAME }}
+          MODEL_NAME: ${{ steps.extract-inputs.outputs.MODEL_NAME }}
         run: |
           export WORK_IMAGE_NAME=flagperf-kunlunxin-pytorch:t_v0.1_${MODEL_NAME:-unknown}_${WORK_TIMESTAMP:-unknown} &&
           echo "WORK_IMAGE_NAME=${WORK_IMAGE_NAME}" &&

--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -178,6 +178,7 @@ jobs:
 
       # 8. Remove training image
       - name: 8. Remove training image
+        if: ${{ always() && (inputs.case1x1 != '' || inputs.case1x8 != '' )}}
         env:
           WORK_TIMESTAMP: ${{ steps.work-timestamp.outputs.WORK_TIMESTAMP }}
           MODEL_NAME: ${{ steps.get-model-name.outputs.MODEL_NAME }}

--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -195,9 +195,21 @@ jobs:
           RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
         run: |
           mkdir -p "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/"
+      
+      # 6.6 Modify xpu_monitor.pid in training/kunlunxin/kunlunxin_monitor.py
+      - name: 6.6 Modify xpu_monitor.pid in training/kunlunxin/kunlunxin_monitor.py
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+        run: |
+          export XPU_MONITOR_PID_FILEPATH="$(realpath ${PWD}/..)/xpu_monitor.pid" &&
+          echo "pid_fn=${XPU_MONITOR_PID_FILEPATH}" &&
+          export XPU_MONITOR_PID_FILEPATH="$(echo ${XPU_MONITOR_PID_FILEPATH} | sed 's/\//\\\//g')" &&
+          export SED_PATTERN="s/pid_fn = str('\/tmp\/xpu_monitor.pid')/pid_fn = str('${XPU_MONITOR_PID_FILEPATH}')/g" &&
+          echo "SED_PATTERN=${SED_PATTERN}" &&
+          sed -i "${SED_PATTERN}" ${WORK_DIRECTORY}/training/kunlunxin/kunlunxin_monitor.py
 
-      # 6.6 Run test
-      - name: 6.6 Run test
+      # 6.7 Run test
+      - name: 6.7 Run test
         env:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
         run: |
@@ -213,7 +225,7 @@ jobs:
           RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
         run: |
           echo "LOG_FILEPATH=${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/rank0.out.log" &&
-          grep '"event": "FINISHED"' "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/rank0.out.log"
+          grep '"event": "FINISHED"' "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/rank0.out.log" > /dev/null
 
       - name: 7.2 Verify 1x8 case result
         if: ${{ inputs.case1x8 != '' }}
@@ -222,9 +234,9 @@ jobs:
           RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
         run: |
           echo "LOG_FILEPATH=${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/rank0.out.log" &&
-          grep '"event": "FINISHED"' "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/rank0.out.log"
+          grep '"event": "FINISHED"' "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/rank0.out.log" > /dev/null
 
-      # 8.1 Fetch kunlunxin_monitor result
+      # 8.1 Fetch 1x1 kunlunxin_monitor result
       - name: 8.1 Fetch 1x1 kunlunxin_monitor result
         if: ${{ inputs.case1x1 != '' }}
         env:
@@ -232,15 +244,45 @@ jobs:
           RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
         run: |
           cat "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/kunlunxin_monitor.log" || true
+        
+      # 8.2 Get 1x1 kunlunxin_monitor max memory usage
+      - name: 8.2 Get 1x1 kunlunxin_monitor max memory usage
+        if: ${{ inputs.case1x1 != '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+          RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
+        run: |
+          cat "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/kunlunxin_monitor.log" | \
+          grep 'MiB' | \
+          awk '{ print $3 }' | \
+          sed "s/MiB//g" | \
+          sort -n | \
+          tail -n 1 | \
+          xargs -I{} printf "1x1 case max memory usage: {} MB\n" || true
 
-      # 8.2 Fetch kunlunxin_monitor result
-      - name: 8.2 Fetch 1x1 kunlunxin_monitor result
+      # 8.3 Fetch 1x8 kunlunxin_monitor result
+      - name: 8.3 Fetch 1x8 kunlunxin_monitor result
         if: ${{ inputs.case1x8 != '' }}
         env:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
           RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
         run: |
           cat "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/kunlunxin_monitor.log" || true
+
+      # 8.4 Get 1x8 kunlunxin_monitor max memory usage
+      - name: 8.4 Get 1x8 kunlunxin_monitor max memory usage
+        if: ${{ inputs.case1x8 != '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+          RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
+        run: |
+            cat "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/kunlunxin_monitor.log" | \
+            grep 'MiB' | \
+            awk '{ print $3 }' | \
+            sed "s/MiB//g" | \
+            sort -n | \
+            tail -n 1 | \
+            xargs -I{} printf "1x8 case max memory usage: {} MB\n" || true
 
       # 9. Remove training container and image
       - name: 9. Remove training container and image

--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -19,23 +19,23 @@ jobs:
     runs-on: [ self-hosted, klx, r480 ]
     steps:
       # 1. Checkout
-      - name: Checkout code
+      - name: 1. Checkout code
         uses: actions/checkout@master
         with:
           fetch-depth: 1
       
       # 2. Create tmp directory
-      - name: Retrieve the current timestamp
+      - name: 2.1 Retrieve the current timestamp
         id: work-timestamp
         run: echo "WORK_TIMESTAMP=$(date +"%Y-%m%d-%H%M%S")"  >> "$GITHUB_OUTPUT"
 
-      - name: Set work directory variable
+      - name: 2.2 Set work directory variable
         id: work-directory
         env:
           WORK_TIMESTAMP: ${{ steps.work-timestamp.outputs.WORK_TIMESTAMP }}
         run: echo "WORK_DIRECTORY=$(realpath ${PWD}/..)/FlagPerf-$WORK_TIMESTAMP"  >> "$GITHUB_OUTPUT"
 
-      - name: Create work directory and copy the whole directory
+      - name: 2.3 Create work directory and copy the whole directory
         env:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
         run: |
@@ -43,7 +43,7 @@ jobs:
           cp -r * ${WORK_DIRECTORY}
 
       # 3. Setup basic information in test_conf.py
-      - name: Setup test_conf.py
+      - name: 3. Setup test_conf.py
         env:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
         run: |
@@ -57,28 +57,28 @@ jobs:
           cat ${TEST_CONF_FILEPATH}
 
       # 4. Setup cases in test_conf.py
-      - name: Setup 1x1 case and 1x8 case in test_conf.py
+      - name: 4.1 Setup 1x1 case and 1x8 case in test_conf.py
         if: ${{ inputs.case1x1 != '' && inputs.case1x8 != '' }}
         env:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
         run: |
           echo "CASES = { '${{ inputs.case1x1 }}' : '${{ inputs.dataset_path }}', '${{ inputs.case1x8 }}' : '${{ inputs.dataset_path }}' }" >> ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py &&
           cat ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py
-      - name: Setup 1x1 case in test_conf.py
+      - name: 4.2 Setup 1x1 case in test_conf.py
         if: ${{ inputs.case1x1 != '' && inputs.case1x8 == '' }}
         env:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
         run: |
           echo "CASES = { '${{ inputs.case1x1 }}' : '${{ inputs.dataset_path }}' }" >> ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py &&
           cat ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py
-      - name: Setup 1x8 case in test_conf.py
+      - name: 4.3 Setup 1x8 case in test_conf.py
         if: ${{ inputs.case1x1 == '' && inputs.case1x8 != '' }}
         env:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
         run: |
           echo "CASES = { '${{ inputs.case1x1 }}' : '${{ inputs.dataset_path }}' }" >> ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py &&
           cat ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py
-      - name: Setup empty cases in test_conf.py
+      - name: 4.4 Setup empty cases in test_conf.py
         if: ${{ inputs.case1x1 == '' && inputs.case1x8 == '' }}
         env:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
@@ -87,7 +87,7 @@ jobs:
           ls non_existent_file.txt
 
       # 5. Setup cluster_conf.py
-      - name: Setup cluster_conf.py
+      - name: 5. Setup cluster_conf.py
         env:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
         run: |
@@ -95,7 +95,7 @@ jobs:
           cat ${WORK_DIRECTORY}/training/run_benchmarks/config/cluster_conf.py
 
       # 6. Run test
-      - name: Run test
+      - name: 6. Run test
         env:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
         run: |
@@ -105,13 +105,13 @@ jobs:
 
       # 7. Verify test result
       # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
-      - name: Get run result name
+      - name: 7.1 Get run result name
         id: run-result-name
         env:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
         run: echo "RUN_RESULT_NAME=$(cat ${WORK_DIRECTORY}/training/tmp_run.log | grep 'Initialize logger with log path:' | egrep -o 'run[0-9]+')"  >> "$GITHUB_OUTPUT"
 
-      - name: Verify 1x1 case result
+      - name: 7.2 Verify 1x1 case result
         if: ${{ inputs.case1x1 != '' }}
         env:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
@@ -120,7 +120,7 @@ jobs:
           cat ${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/rank0.out.log
           grep "FINISHED" "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/rank0.out.log"
 
-      - name: Verify 1x8 case result
+      - name: 7.3 Verify 1x8 case result
         if: ${{ inputs.case1x8 != '' }}
         env:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}

--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -5,25 +5,29 @@ on:
   workflow_dispatch:
     inputs:
       case1x1:
-        description: '1x1 case name that filled into test_conf.py (empty means not to execute)'
-        default: 'model:framework:hardwareID:1:1:1'
+        description: 'e.g. model:framework:hardwareID:1:1:1 (empty means not to execute)'
       case1x8:
-        description: '1x8 case name that filled into test_conf.py (empty means not to execute)'
-        default: 'model:framework:hardwareID:1:8:1'
+        description: 'e.g. model:framework:hardwareID:1:8:1 (empty means not to execute)'
       dataset_path:
         description: 'dataset path filled into test_conf.py'
-        default: 'dataset path'
         required: true
 jobs:
   run-klx-training-test:
     runs-on: [ self-hosted, klx, r480 ]
     steps:
+      # 0. Display inputs
+      - name: 0. Display inputs
+        run: |
+          echo "case1x1=${{ inputs.case1x1 }}" &&
+          echo "case1x8=${{ inputs.case1x8 }}" &&
+          echo "dataset_path=${{ inputs.dataset_path }}"
+
       # 1. Checkout
       - name: 1. Checkout code
         uses: actions/checkout@master
         with:
           fetch-depth: 1
-      
+
       # 2. Create tmp directory
       - name: 2.1 Retrieve the current timestamp
         id: work-timestamp
@@ -94,8 +98,25 @@ jobs:
           echo "HOSTS = ['127.0.0.1']" >> ${WORK_DIRECTORY}/training/run_benchmarks/config/cluster_conf.py &&
           cat ${WORK_DIRECTORY}/training/run_benchmarks/config/cluster_conf.py
 
-      # 6. Run test
-      - name: 6. Run test
+      # 6.1 Get model name
+      - name: 6.1 Get model name
+        id: get-model-name
+        run: echo "MODEL_NAME=$(echo '${{ inputs.case1x1 }}' | cut -d ':' -f1)"  >> "$GITHUB_OUTPUT"
+
+      # 6.2 Generate VERSION for run.py
+      - name: 6.2 Generate VERSION for run.py
+        env:
+          WORK_TIMESTAMP: ${{ steps.work-timestamp.outputs.WORK_TIMESTAMP }}
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+          MODEL_NAME: ${{ steps.get-model-name.outputs.MODEL_NAME }}
+        run: |
+          export SED_PATTERN="s/VERSION = \"v0.1\"/VERSION = \"v0.1_${MODEL_NAME}_${WORK_TIMESTAMP}\"/g" &&
+          echo "SED_PATTERN=${SED_PATTERN}" &&
+          sed -i "${SED_PATTERN}" ${WORK_DIRECTORY}/training/run_benchmarks/run.py &&
+          echo "IMAGE_NAME=flagperf-kunlunxin-pytorch:t_v0.1_${MODEL_NAME}_${WORK_TIMESTAMP}"
+
+      # 6.3 Run test
+      - name: 6.3 Run test
         env:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
         run: |
@@ -128,3 +149,10 @@ jobs:
         run: |
           cat ${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/rank0.out.log &&
           grep '"event": "FINISHED"' "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/rank0.out.log"
+
+      # 8. Remove training image
+      - name: 8. Remove training image
+        env:
+          WORK_TIMESTAMP: ${{ steps.work-timestamp.outputs.WORK_TIMESTAMP }}
+          MODEL_NAME: ${{ steps.get-model-name.outputs.MODEL_NAME }}
+        run: docker rmi -f flagperf-kunlunxin-pytorch:t_v0.1_${MODEL_NAME}_${WORK_TIMESTAMP} || true

--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -34,7 +34,10 @@ jobs:
         run: |
           echo "case1x1=${{ inputs.case1x1 }}" &&
           echo "case1x8=${{ inputs.case1x8 }}" &&
-          echo "dataset_path=${{ inputs.dataset_path }}"
+          echo "dataset_path=${{ inputs.dataset_path }}" &&
+          echo "pip_source=${{ inputs.pip_source }}" &&
+          echo "max_epoch=${{ inputs.max_epoch }}" &&
+          echo "max_samples_termination=${{ inputs.max_samples_termination }}"
 
       # 1. Checkout
       - name: 1. Checkout code

--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -118,7 +118,7 @@ jobs:
           RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
         run: |
           cat ${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/rank0.out.log
-          grep "FINISHED" "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/rank0.out.log"
+          grep '"event": "FINISHED"' "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/rank0.out.log"
 
       - name: 7.3 Verify 1x8 case result
         if: ${{ inputs.case1x8 != '' }}
@@ -127,4 +127,4 @@ jobs:
           RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
         run: |
           cat ${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/rank0.out.log
-          grep "FINISHED" "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/rank0.out.log"
+          grep '"event": "FINISHED"' "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/rank0.out.log"

--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -1,3 +1,4 @@
+# 配置和使用文档请参考: https://github.com/FlagOpen/FlagPerf/pull/318
 name: klx-training-pre-pr-check
 
 on:
@@ -30,7 +31,7 @@ jobs:
           echo "ACCE_VISIBLE_DEVICE_ENV_NAME = 'XPU_VISIBLE_DEVICES'" >> training/run_benchmarks/config/test_conf.py &&
           echo "PIP_SOURCE = 'https://pypi.tuna.tsinghua.edu.cn/simple'" &&
           echo "FLAGPERF_PATH = '${PWD}/training'" >> training/run_benchmarks/config/test_conf.py &&
-          echo "FLAGPERF_LOG_PATH = '${PWD}/training/results/'" >> training/run_benchmarks/config/test_conf.py &&
+          echo "FLAGPERF_LOG_PATH = '${PWD}/training/result/'" >> training/run_benchmarks/config/test_conf.py &&
           echo "CASES = {'${{ inputs.case1x1 }}' : '${{ inputs.dataset_path }}', '${{ inputs.case1x8 }}' : '${{ inputs.dataset_path }}' }" >> training/run_benchmarks/config/test_conf.py &&
           cat training/run_benchmarks/config/test_conf.py
       - name: Setup cluster_conf.py

--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -11,6 +11,10 @@ on:
       dataset_path:
         description: 'dataset path filled into test_conf.py'
         required: true
+      pip_source:
+        description: 'value of PIP_SOURCE in test_conf.py'
+        default: 'https://pypi.tuna.tsinghua.edu.cn/simple'
+        required: true
 jobs:
   run-klx-training-test:
     runs-on: [ self-hosted, klx, r480 ]
@@ -55,7 +59,7 @@ jobs:
           echo "VENDOR = 'kunlunxin'" >> ${TEST_CONF_FILEPATH} &&
           echo "ACCE_CONTAINER_OPT = '--device=/dev/xpu0 --device=/dev/xpu1 --device=/dev/xpu2 --device=/dev/xpu3 --device=/dev/xpu4 --device=/dev/xpu5 --device=/dev/xpu6 --device=/dev/xpu7 --device=/dev/xpuctrl'" >> ${TEST_CONF_FILEPATH} &&
           echo "ACCE_VISIBLE_DEVICE_ENV_NAME = 'XPU_VISIBLE_DEVICES'" >> ${TEST_CONF_FILEPATH} &&
-          echo "PIP_SOURCE = 'https://pypi.tuna.tsinghua.edu.cn/simple'" >> ${TEST_CONF_FILEPATH} &&
+          echo "PIP_SOURCE = '${{ inputs.pip_source }}'" >> ${TEST_CONF_FILEPATH} &&
           echo "FLAGPERF_PATH = '${WORK_DIRECTORY}/training'" >> ${TEST_CONF_FILEPATH} &&
           echo "FLAGPERF_LOG_PATH = '${WORK_DIRECTORY}/training/result/'" >> ${TEST_CONF_FILEPATH} &&
           cat ${TEST_CONF_FILEPATH}
@@ -164,7 +168,7 @@ jobs:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
           RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
         run: |
-          cat ${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/rank0.out.log &&
+          echo "LOG_FILEPATH=${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/rank0.out.log" &&
           grep '"event": "FINISHED"' "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/rank0.out.log"
 
       - name: 7.3 Verify 1x8 case result
@@ -173,7 +177,7 @@ jobs:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
           RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
         run: |
-          cat ${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/rank0.out.log &&
+          echo "LOG_FILEPATH=${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/rank0.out.log" &&
           grep '"event": "FINISHED"' "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/rank0.out.log"
 
       # 8. Remove training image

--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -83,7 +83,7 @@ jobs:
         env:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
         run: |
-          echo "At least one of case1x1 and case1x8 is not empty！" &&
+          echo "At least one of case1x1 and case1x8 is not empty!" &&
           ls non_existent_file.txt
 
       # 5. Setup cluster_conf.py
@@ -117,7 +117,7 @@ jobs:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
           RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
         run: |
-          cat ${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/rank0.out.log
+          cat ${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/rank0.out.log &&
           grep '"event": "FINISHED"' "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/rank0.out.log"
 
       - name: 7.3 Verify 1x8 case result
@@ -126,5 +126,5 @@ jobs:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
           RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
         run: |
-          cat ${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/rank0.out.log
+          cat ${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/rank0.out.log &&
           grep '"event": "FINISHED"' "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/rank0.out.log"

--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -61,12 +61,15 @@ jobs:
           cat ${TEST_CONF_FILEPATH}
 
       # 4.1 Get model name
-      - name: 6.1 Get model name
+      - name: 4.1 Get model name
         id: get-model-name
-        run: echo "MODEL_NAME=$(echo '${{ inputs.case1x1 }}' | cut -d ':' -f1)"  >> "$GITHUB_OUTPUT"
+        run: |
+          export MODEL_NAME_1x1=$(echo '${{ inputs.case1x1 }}' | cut -d ':' -f1) &&
+          export MODEL_NAME_1x8=$(echo '${{ inputs.case1x8 }}' | cut -d ':' -f1) &&
+          echo "MODEL_NAME=${MODEL_NAME_1x1:-${MODEL_NAME_1x8}}"  >> "$GITHUB_OUTPUT"
 
       # 4.2 Setup cases in test_conf.py
-      - name: 4.1 Setup 1x1 case and 1x8 case in test_conf.py
+      - name: 4.2 Setup 1x1 case and 1x8 case in test_conf.py
         if: ${{ inputs.case1x1 != '' && inputs.case1x8 != '' }}
         env:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}

--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -60,7 +60,12 @@ jobs:
           echo "FLAGPERF_LOG_PATH = '${WORK_DIRECTORY}/training/result/'" >> ${TEST_CONF_FILEPATH} &&
           cat ${TEST_CONF_FILEPATH}
 
-      # 4. Setup cases in test_conf.py
+      # 4.1 Get model name
+      - name: 6.1 Get model name
+        id: get-model-name
+        run: echo "MODEL_NAME=$(echo '${{ inputs.case1x1 }}' | cut -d ':' -f1)"  >> "$GITHUB_OUTPUT"
+
+      # 4.2 Setup cases in test_conf.py
       - name: 4.1 Setup 1x1 case and 1x8 case in test_conf.py
         if: ${{ inputs.case1x1 != '' && inputs.case1x8 != '' }}
         env:
@@ -89,6 +94,28 @@ jobs:
         run: |
           echo "At least one of case1x1 and case1x8 is not empty!" &&
           ls non_existent_file.txt
+      
+      # 4.3 Setup config_R300x1x1.py
+      - name: 4.3 Setup config_R300x1x1.py
+        if: ${{ inputs.case1x1 != '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+          MODEL_NAME: ${{ steps.get-model-name.outputs.MODEL_NAME }}
+        run: |
+          echo "max_epoch = 1" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x1.py &&
+          echo "max_samples_termination = 20" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x1.py &&
+          cat ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x1.py
+
+      # 4.4 Setup config_R300x1x8.py
+      - name: 4.4 Setup config_R300x1x8.py
+        if: ${{ inputs.case1x8 != '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+          MODEL_NAME: ${{ steps.get-model-name.outputs.MODEL_NAME }}
+        run: |
+          echo "max_epoch = 1" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x8.py &&
+          echo "max_samples_termination = 20" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x8.py &&
+          cat ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x8.py
 
       # 5. Setup cluster_conf.py
       - name: 5. Setup cluster_conf.py
@@ -98,12 +125,7 @@ jobs:
           echo "HOSTS = ['127.0.0.1']" >> ${WORK_DIRECTORY}/training/run_benchmarks/config/cluster_conf.py &&
           cat ${WORK_DIRECTORY}/training/run_benchmarks/config/cluster_conf.py
 
-      # 6.1 Get model name
-      - name: 6.1 Get model name
-        id: get-model-name
-        run: echo "MODEL_NAME=$(echo '${{ inputs.case1x1 }}' | cut -d ':' -f1)"  >> "$GITHUB_OUTPUT"
-
-      # 6.2 Generate VERSION for run.py
+      # 6.1 Generate VERSION for run.py
       - name: 6.2 Generate VERSION for run.py
         env:
           WORK_TIMESTAMP: ${{ steps.work-timestamp.outputs.WORK_TIMESTAMP }}
@@ -115,7 +137,7 @@ jobs:
           sed -i "${SED_PATTERN}" ${WORK_DIRECTORY}/training/run_benchmarks/run.py &&
           echo "IMAGE_NAME=flagperf-kunlunxin-pytorch:t_v0.1_${MODEL_NAME}_${WORK_TIMESTAMP}"
 
-      # 6.3 Run test
+      # 6.2 Run test
       - name: 6.3 Run test
         env:
           WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}

--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -180,10 +180,14 @@ jobs:
           echo "LOG_FILEPATH=${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/rank0.out.log" &&
           grep '"event": "FINISHED"' "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/rank0.out.log"
 
-      # 8. Remove training image
-      - name: 8. Remove training image
+      # 8. Remove training container and image
+      - name: 8. Remove training container and image
         if: ${{ always() && (inputs.case1x1 != '' || inputs.case1x8 != '' )}}
         env:
           WORK_TIMESTAMP: ${{ steps.work-timestamp.outputs.WORK_TIMESTAMP }}
           MODEL_NAME: ${{ steps.get-model-name.outputs.MODEL_NAME }}
-        run: docker rmi -f flagperf-kunlunxin-pytorch:t_v0.1_${MODEL_NAME}_${WORK_TIMESTAMP} || true
+        run: |
+          export WORK_IMAGE_NAME=flagperf-kunlunxin-pytorch:t_v0.1_${MODEL_NAME:-unknown}_${WORK_TIMESTAMP:-unknown} &&
+          echo "WORK_IMAGE_NAME=${WORK_IMAGE_NAME}" &&
+          docker rm -f $(docker ps -a -q --filter ancestor=${WORK_IMAGE_NAME}) || true &&
+          docker rmi -f ${WORK_IMAGE_NAME} || true

--- a/.github/workflows/klx-training-pre-pr-check.yml
+++ b/.github/workflows/klx-training-pre-pr-check.yml
@@ -23,78 +23,108 @@ jobs:
         uses: actions/checkout@master
         with:
           fetch-depth: 1
+      
+      # 2. Create tmp directory
+      - name: Retrieve the current timestamp
+        id: work-timestamp
+        run: echo "WORK_TIMESTAMP=$(date +"%Y-%m%d-%H%M%S")"  >> "$GITHUB_OUTPUT"
 
-      # 2. Setup basic information in test_conf.py
-      - name: Setup test_conf.py
+      - name: Set work directory variable
+        id: work-directory
+        env:
+          WORK_TIMESTAMP: ${{ steps.work-timestamp.outputs.WORK_TIMESTAMP }}
+        run: echo "WORK_DIRECTORY=$(realpath ${PWD}/..)/FlagPerf-$WORK_TIMESTAMP"  >> "$GITHUB_OUTPUT"
+
+      - name: Create work directory and copy the whole directory
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
         run: |
-          echo "VENDOR = 'kunlunxin'" >> training/run_benchmarks/config/test_conf.py &&
-          echo "ACCE_CONTAINER_OPT = '--device=/dev/xpu0 --device=/dev/xpu1 --device=/dev/xpu2 --device=/dev/xpu3 --device=/dev/xpu4 --device=/dev/xpu5 --device=/dev/xpu6 --device=/dev/xpu7 --device=/dev/xpuctrl'" >> training/run_benchmarks/config/test_conf.py &&
-          echo "ACCE_VISIBLE_DEVICE_ENV_NAME = 'XPU_VISIBLE_DEVICES'" >> training/run_benchmarks/config/test_conf.py &&
-          echo "PIP_SOURCE = 'https://pypi.tuna.tsinghua.edu.cn/simple'" &&
-          echo "FLAGPERF_PATH = '${PWD}/training'" >> training/run_benchmarks/config/test_conf.py &&
-          echo "FLAGPERF_LOG_PATH = '${PWD}/training/result/'" >> training/run_benchmarks/config/test_conf.py &&
-          cat training/run_benchmarks/config/test_conf.py
+          mkdir ${WORK_DIRECTORY} &&
+          cp -r * ${WORK_DIRECTORY}
 
-      # 3. Setup cases in test_conf.py
+      # 3. Setup basic information in test_conf.py
+      - name: Setup test_conf.py
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+        run: |
+          export TEST_CONF_FILEPATH=${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py
+          echo "VENDOR = 'kunlunxin'" >> ${TEST_CONF_FILEPATH} &&
+          echo "ACCE_CONTAINER_OPT = '--device=/dev/xpu0 --device=/dev/xpu1 --device=/dev/xpu2 --device=/dev/xpu3 --device=/dev/xpu4 --device=/dev/xpu5 --device=/dev/xpu6 --device=/dev/xpu7 --device=/dev/xpuctrl'" >> ${TEST_CONF_FILEPATH} &&
+          echo "ACCE_VISIBLE_DEVICE_ENV_NAME = 'XPU_VISIBLE_DEVICES'" >> ${TEST_CONF_FILEPATH} &&
+          echo "PIP_SOURCE = 'https://pypi.tuna.tsinghua.edu.cn/simple'" &&
+          echo "FLAGPERF_PATH = '${WORK_DIRECTORY}/training'" >> ${TEST_CONF_FILEPATH} &&
+          echo "FLAGPERF_LOG_PATH = '${WORK_DIRECTORY}/training/result/'" >> ${TEST_CONF_FILEPATH} &&
+          cat ${TEST_CONF_FILEPATH}
+
+      # 4. Setup cases in test_conf.py
       - name: Setup 1x1 case and 1x8 case in test_conf.py
         if: ${{ inputs.case1x1 != '' && inputs.case1x8 != '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
         run: |
-          echo "CASES = { '${{ inputs.case1x1 }}' : '${{ inputs.dataset_path }}', '${{ inputs.case1x8 }}' : '${{ inputs.dataset_path }}' }" >> training/run_benchmarks/config/test_conf.py &&
-          cat training/run_benchmarks/config/test_conf.py
+          echo "CASES = { '${{ inputs.case1x1 }}' : '${{ inputs.dataset_path }}', '${{ inputs.case1x8 }}' : '${{ inputs.dataset_path }}' }" >> ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py &&
+          cat ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py
       - name: Setup 1x1 case in test_conf.py
         if: ${{ inputs.case1x1 != '' && inputs.case1x8 == '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
         run: |
-          echo "CASES = { '${{ inputs.case1x1 }}' : '${{ inputs.dataset_path }}' }" >> training/run_benchmarks/config/test_conf.py &&
-          cat training/run_benchmarks/config/test_conf.py
+          echo "CASES = { '${{ inputs.case1x1 }}' : '${{ inputs.dataset_path }}' }" >> ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py &&
+          cat ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py
       - name: Setup 1x8 case in test_conf.py
         if: ${{ inputs.case1x1 == '' && inputs.case1x8 != '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
         run: |
-          echo "CASES = { '${{ inputs.case1x1 }}' : '${{ inputs.dataset_path }}' }" >> training/run_benchmarks/config/test_conf.py &&
-          cat training/run_benchmarks/config/test_conf.py
+          echo "CASES = { '${{ inputs.case1x1 }}' : '${{ inputs.dataset_path }}' }" >> ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py &&
+          cat ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py
       - name: Setup empty cases in test_conf.py
         if: ${{ inputs.case1x1 == '' && inputs.case1x8 == '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
         run: |
           echo "At least one of case1x1 and case1x8 is not empty！" &&
           ls non_existent_file.txt
 
-      # 4. Setup cluster_conf.py
+      # 5. Setup cluster_conf.py
       - name: Setup cluster_conf.py
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
         run: |
-          echo "HOSTS = ['127.0.0.1']" >> training/run_benchmarks/config/cluster_conf.py &&
-          cat training/run_benchmarks/config/cluster_conf.py
+          echo "HOSTS = ['127.0.0.1']" >> ${WORK_DIRECTORY}/training/run_benchmarks/config/cluster_conf.py &&
+          cat ${WORK_DIRECTORY}/training/run_benchmarks/config/cluster_conf.py
 
-      # 5. Run test
+      # 6. Run test
       - name: Run test
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
         run: |
-          pushd training &&
+          pushd ${WORK_DIRECTORY}/training &&
           python3 run_benchmarks/run.py 2>&1 | tee tmp_run.log &&
           popd
 
-      # 6. Verify test result
+      # 7. Verify test result
       # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
       - name: Get run result name
         id: run-result-name
-        run: echo "RUN_RESULT_NAME=$(cat training/tmp_run.log | grep 'Initialize logger with log path:' | egrep -o 'run[0-9]+')"  >> "$GITHUB_OUTPUT"
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+        run: echo "RUN_RESULT_NAME=$(cat ${WORK_DIRECTORY}/training/tmp_run.log | grep 'Initialize logger with log path:' | egrep -o 'run[0-9]+')"  >> "$GITHUB_OUTPUT"
 
       - name: Verify 1x1 case result
         if: ${{ inputs.case1x1 != '' }}
         env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
           RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
         run: |
-          cat training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 != '' }}/round1/127.0.0.1_noderank0/rank0.out.log
-          grep "FINISHED" "training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 != '' }}/round1/127.0.0.1_noderank0/rank0.out.log"
+          cat ${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/rank0.out.log
+          grep "FINISHED" "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/rank0.out.log"
 
       - name: Verify 1x8 case result
         if: ${{ inputs.case1x8 != '' }}
         env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
           RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
         run: |
-          cat training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 != '' }}/round1/127.0.0.1_noderank0/rank0.out.log
-          grep "FINISHED" "training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 != '' }}/round1/127.0.0.1_noderank0/rank0.out.log"
-
-      # 7. Clean job
-      - name: Remove tmp_run.log, restore test_conf.py and cluster_conf.py
-        run: |
-          rm -f training/tmp_run.log &&
-          git checkout training/run_benchmarks/config/test_conf.py &&
-          git checkout training/run_benchmarks/config/cluster_conf.py
+          cat ${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/rank0.out.log
+          grep "FINISHED" "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/rank0.out.log"

--- a/.github/workflows/klx-training-remove-image.yml
+++ b/.github/workflows/klx-training-remove-image.yml
@@ -1,0 +1,20 @@
+name: klx-training-remove-image
+on:
+  workflow_dispatch:
+    inputs:
+      image_name:
+        description: 'e.g. flagperf-kunlunxin-pytorch:t_v0.1 (empty means not to remove)'
+jobs:
+  remove-klx-training-image:
+    # 只适用于单台测试机器的场景, 多台测试机器时，只会选择某一台执行
+    runs-on: [ self-hosted, klx, r480 ]
+    steps:
+      - name: Display inputs
+        run: echo "image_name=${{ inputs.image_name }}"
+
+      - name: Display docker images list
+        run: docker images | grep '^flagperf-kunlunxin-pytorch' || true
+
+      - name: Remove kunlunxin training images
+        if: ${{ inputs.image_name != '' }}
+        run: docker rmi -f ${{ inputs.image_name }} || true

--- a/.github/workflows/klx-training-remove-image.yml
+++ b/.github/workflows/klx-training-remove-image.yml
@@ -11,10 +11,13 @@ jobs:
     steps:
       - name: Display inputs
         run: echo "image_name=${{ inputs.image_name }}"
-
-      - name: Verify inputs
-        if: ${{ inputs.image_name != '' }}
-        run: echo "Verifying image_name..." && echo "${{ inputs.image_name }}" | egrep "^flagperf-kunlunxin-pytorch:[0-9a-zA-Z\.\-_]+$" > /dev/null && echo "success!"
+      
+      # 说明: 
+      #   可以指定image的id, 也可以指定image的tag
+      #   由于只能由仓库成员手动触发该workflow, 因此无需对输入进行校验
+      # - name: Verify inputs
+      #   if: ${{ inputs.image_name != '' }}
+      #   run: echo "Verifying image_name..." && echo "${{ inputs.image_name }}" | egrep "^flagperf-kunlunxin-pytorch:[0-9a-zA-Z\.\-_]+$" > /dev/null && echo "success!"
 
       - name: Display docker images list
         run: docker images | grep '^flagperf-kunlunxin-pytorch' || true

--- a/.github/workflows/klx-training-remove-image.yml
+++ b/.github/workflows/klx-training-remove-image.yml
@@ -12,6 +12,10 @@ jobs:
       - name: Display inputs
         run: echo "image_name=${{ inputs.image_name }}"
 
+      - name: Verify inputs
+        if: ${{ inputs.image_name != '' }}
+        run: echo "Verifying image_name..." && echo "${{ inputs.image_name }}" | egrep "^flagperf-kunlunxin-pytorch:[0-9a-zA-Z\.\-_]+$" > /dev/null && echo "success!"
+
       - name: Display docker images list
         run: docker images | grep '^flagperf-kunlunxin-pytorch' || true
 

--- a/.github/workflows/klx-training-remove-image.yml
+++ b/.github/workflows/klx-training-remove-image.yml
@@ -17,4 +17,7 @@ jobs:
 
       - name: Remove kunlunxin training images
         if: ${{ inputs.image_name != '' }}
-        run: docker rmi -f ${{ inputs.image_name }} || true
+        run: |
+          export IMAGE_NAME=${{ inputs.image_name }} &&
+          docker rm -f $(docker ps -a -q --filter ancestor=${IMAGE_NAME}) || true &&
+          docker rmi -f ${IMAGE_NAME} || true

--- a/.github/workflows/klx-training-test-manually.yml
+++ b/.github/workflows/klx-training-test-manually.yml
@@ -1,0 +1,308 @@
+# 配置和使用文档请参考: https://github.com/FlagOpen/FlagPerf/pull/318
+name: klx-training-test-manually
+
+on:
+  workflow_dispatch:
+    inputs:
+      case1x1:
+        description: 'e.g. model:framework:hardwareID:1:1:1 (empty means not to execute)'
+      case1x8:
+        description: 'e.g. model:framework:hardwareID:1:8:1 (empty means not to execute)'
+      dataset_path:
+        description: 'dataset path filled into test_conf.py'
+        required: true
+      pip_source:
+        description: 'value of PIP_SOURCE in test_conf.py'
+        default: 'https://pypi.tuna.tsinghua.edu.cn/simple'
+        required: true
+      max_epoch:
+        description: 'value of max_epoch in config_R300_xxx.py'
+        type: number
+        default: 1
+        required: true
+      max_samples_termination:
+        description: 'value of max_samples_termination in config_R300_xxx.py'
+        type: number
+        default: 10
+        required: true
+jobs:
+  run-klx-training-test:
+    runs-on: [ self-hosted, klx, r480 ]
+    steps:
+      # 0.1 Display inputs
+      - name: 0.1 Display inputs
+        run: |
+          echo "case1x1=${{ inputs.case1x1 }}" &&
+          echo "case1x8=${{ inputs.case1x8 }}" &&
+          echo "dataset_path=${{ inputs.dataset_path }}" &&
+          echo "pip_source=${{ inputs.pip_source }}" &&
+          echo "max_epoch=${{ inputs.max_epoch }}" &&
+          echo "max_samples_termination=${{ inputs.max_samples_termination }}"
+
+      # 0.2 Verify inputs
+      - name: 0.2 Verify inputs
+        run: |
+          export CASE1x1="${{ inputs.case1x1 }}" && export CASE1x8="${{ inputs.case1x8 }}" &&
+          echo "Verifying case1x1..." && echo "${CASE1x1:-model:framework:hardwareID:1:1:1}" | egrep "^[0-9a-zA-Z_\-]+:[0-9a-zA-Z_\-\.]+:[0-9a-zA-Z_\-\.]+:1:1:1$" > /dev/null && echo "success!" &&
+          echo "Verifying case1x8..." && echo "${CASE1x8:-model:framework:hardwareID:1:8:1}" | egrep "^[0-9a-zA-Z_\-]+:[0-9a-zA-Z_\-\.]+:[0-9a-zA-Z_\-\.]+:1:8:1$" > /dev/null && echo "success!" &&
+          echo "Verifying dataset_path..." && echo "${{ inputs.dataset_path }}" | egrep "^([0-9a-zA-Z\/\._\-\:]+)$" > /dev/null && echo "success!" &&
+          echo "Verifying pip_source..." && echo "${{ inputs.pip_source }}" | egrep "^((https:\/\/)|(http:\/\/))?(www\.)?[a-zA-Z0-9\.\/]+$" > /dev/null && echo "success!" &&
+          echo "Verifying max_epoch..." && echo "${{ inputs.max_epoch }}" | egrep "^[0-9]+$" > /dev/null && echo "success!" &&
+          echo "Verifying max_samples_termination..." && echo "${{ inputs.max_samples_termination }}" | egrep "^[0-9]+$" > /dev/null && echo "success!"
+
+      # 1. Checkout
+      - name: 1. Checkout code
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 1
+
+      # 2. Create tmp directory
+      - name: 2.1 Retrieve the current timestamp
+        id: work-timestamp
+        run: echo "WORK_TIMESTAMP=$(date +"%Y%m%d%H%M%S")"  >> "$GITHUB_OUTPUT"
+
+      - name: 2.2 Set work directory variable
+        id: work-directory
+        env:
+          WORK_TIMESTAMP: ${{ steps.work-timestamp.outputs.WORK_TIMESTAMP }}
+        run: echo "WORK_DIRECTORY=$(realpath ${PWD}/..)/FlagPerf$WORK_TIMESTAMP"  >> "$GITHUB_OUTPUT"
+
+      - name: 2.3 Create work directory and copy the whole directory
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+        run: |
+          mkdir ${WORK_DIRECTORY} &&
+          cp -r * ${WORK_DIRECTORY}
+
+      # 3. Setup basic information in test_conf.py
+      - name: 3. Setup test_conf.py
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+        run: |
+          export TEST_CONF_FILEPATH=${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py
+          echo "VENDOR = 'kunlunxin'" >> ${TEST_CONF_FILEPATH} &&
+          echo "ACCE_CONTAINER_OPT = '--device=/dev/xpu0 --device=/dev/xpu1 --device=/dev/xpu2 --device=/dev/xpu3 --device=/dev/xpu4 --device=/dev/xpu5 --device=/dev/xpu6 --device=/dev/xpu7 --device=/dev/xpuctrl'" >> ${TEST_CONF_FILEPATH} &&
+          echo "ACCE_VISIBLE_DEVICE_ENV_NAME = 'XPU_VISIBLE_DEVICES'" >> ${TEST_CONF_FILEPATH} &&
+          echo "PIP_SOURCE = '${{ inputs.pip_source }}'" >> ${TEST_CONF_FILEPATH} &&
+          echo "FLAGPERF_PATH = '${WORK_DIRECTORY}/training'" >> ${TEST_CONF_FILEPATH} &&
+          echo "FLAGPERF_LOG_PATH = '${WORK_DIRECTORY}/training/result/'" >> ${TEST_CONF_FILEPATH} &&
+          cat ${TEST_CONF_FILEPATH}
+
+      # 4.1 Get model name
+      - name: 4.1 Get model name
+        id: get-model-name
+        run: |
+          export MODEL_NAME_1x1=$(echo '${{ inputs.case1x1 }}' | cut -d ':' -f1) &&
+          export MODEL_NAME_1x8=$(echo '${{ inputs.case1x8 }}' | cut -d ':' -f1) &&
+          echo "MODEL_NAME=${MODEL_NAME_1x1:-${MODEL_NAME_1x8}}"  >> "$GITHUB_OUTPUT"
+
+      # 4.2 Setup cases in test_conf.py
+      - name: 4.2 Setup 1x1 case and 1x8 case in test_conf.py
+        if: ${{ inputs.case1x1 != '' && inputs.case1x8 != '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+        run: |
+          echo "CASES = { '${{ inputs.case1x1 }}' : '${{ inputs.dataset_path }}', '${{ inputs.case1x8 }}' : '${{ inputs.dataset_path }}' }" >> ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py &&
+          cat ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py
+      - name: 4.2 Setup 1x1 case in test_conf.py
+        if: ${{ inputs.case1x1 != '' && inputs.case1x8 == '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+        run: |
+          echo "CASES = { '${{ inputs.case1x1 }}' : '${{ inputs.dataset_path }}' }" >> ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py &&
+          cat ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py
+      - name: 4.2 Setup 1x8 case in test_conf.py
+        if: ${{ inputs.case1x1 == '' && inputs.case1x8 != '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+        run: |
+          echo "CASES = { '${{ inputs.case1x8 }}' : '${{ inputs.dataset_path }}' }" >> ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py &&
+          cat ${WORK_DIRECTORY}/training/run_benchmarks/config/test_conf.py
+      - name: 4.2 Setup empty cases in test_conf.py
+        if: ${{ inputs.case1x1 == '' && inputs.case1x8 == '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+        run: |
+          echo "At least one of case1x1 and case1x8 is not empty!" &&
+          ls non_existent_file.txt
+      
+      # 4.3 Setup config_R300x1x1.py
+      - name: 4.3 Setup config_R300x1x1.py
+        if: ${{ inputs.case1x1 != '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+          MODEL_NAME: ${{ steps.get-model-name.outputs.MODEL_NAME }}
+        run: |
+          echo "max_epoch = ${{ inputs.max_epoch }}" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x1.py &&
+          echo "max_samples_termination = ${{ inputs.max_samples_termination }}" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x1.py &&
+          cat ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x1.py
+
+      # 4.4 Setup config_R300x1x8.py
+      - name: 4.4 Setup config_R300x1x8.py
+        if: ${{ inputs.case1x8 != '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+          MODEL_NAME: ${{ steps.get-model-name.outputs.MODEL_NAME }}
+        run: |
+          echo "max_epoch = ${{ inputs.max_epoch }}" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x8.py &&
+          echo "max_samples_termination = ${{ inputs.max_samples_termination }}" >> ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x8.py &&
+          cat ${WORK_DIRECTORY}/training/kunlunxin/${MODEL_NAME}-pytorch/config/config_R300x1x8.py
+
+      # 5. Setup cluster_conf.py(set random master port between 25000 and 26000)
+      - name: 5. Setup cluster_conf.py(set random master port between 25000 and 26000)
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+        run: |
+          echo "HOSTS = ['127.0.0.1']" >> ${WORK_DIRECTORY}/training/run_benchmarks/config/cluster_conf.py &&
+          echo "MASTER_PORT = '$(shuf -i 25000-26000 -n 1)'" >> ${WORK_DIRECTORY}/training/run_benchmarks/config/cluster_conf.py &&
+          cat ${WORK_DIRECTORY}/training/run_benchmarks/config/cluster_conf.py
+
+      # 6.1 Modify VERSION in run.py
+      - name: 6.1 Modify VERSION in run.py
+        env:
+          WORK_TIMESTAMP: ${{ steps.work-timestamp.outputs.WORK_TIMESTAMP }}
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+          MODEL_NAME: ${{ steps.get-model-name.outputs.MODEL_NAME }}
+        run: |
+          export SED_PATTERN="s/VERSION = \"v0.1\"/VERSION = \"v0.1_${MODEL_NAME}_${WORK_TIMESTAMP}\"/g" &&
+          echo "SED_PATTERN=${SED_PATTERN}" &&
+          sed -i "${SED_PATTERN}" ${WORK_DIRECTORY}/training/run_benchmarks/run.py &&
+          echo "IMAGE_NAME=flagperf-kunlunxin-pytorch:t_v0.1_${MODEL_NAME}_${WORK_TIMESTAMP}"
+
+      # 6.2 Get run result name
+      # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
+      - name: 6.2 Get run result name
+        id: run-result-name
+        env:
+          WORK_TIMESTAMP: ${{ steps.work-timestamp.outputs.WORK_TIMESTAMP }}
+        run: echo "RUN_RESULT_NAME=run${WORK_TIMESTAMP}" >> "$GITHUB_OUTPUT"
+
+      # 6.3 Modify timestamp in run.py
+      - name: 6.3 Modify timestamp in run.py
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+          RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
+        run: |
+          export SED_PATTERN="s/timestamp_log_dir = \"run\" + time.strftime(\"%Y%m%d%H%M%S\", time.localtime())/timestamp_log_dir = \"${RUN_RESULT_NAME}\"/g" &&
+          echo "SED_PATTERN=${SED_PATTERN}" &&
+          sed -i "${SED_PATTERN}" ${WORK_DIRECTORY}/training/run_benchmarks/run.py &&
+          echo "timestamp_log_dir=${RUN_RESULT_NAME}" &&
+          grep ${RUN_RESULT_NAME} ${WORK_DIRECTORY}/training/run_benchmarks/run.py
+
+      # 6.4 Create 1x1 result path
+      - name: 6.4 Create 1x1 result path
+        if: ${{ inputs.case1x1 != '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+          RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
+        run: |
+          mkdir -p "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/"
+
+      # 6.5 Create 1x8 result path
+      - name: 6.5 Create 1x8 result path
+        if: ${{ inputs.case1x8 != '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+          RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
+        run: |
+          mkdir -p "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/"
+      
+      # 6.6 Modify xpu_monitor.pid in training/kunlunxin/kunlunxin_monitor.py
+      - name: 6.6 Modify xpu_monitor.pid in training/kunlunxin/kunlunxin_monitor.py
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+        run: |
+          export XPU_MONITOR_PID_FILEPATH="$(realpath ${PWD}/..)/xpu_monitor.pid" &&
+          echo "pid_fn=${XPU_MONITOR_PID_FILEPATH}" &&
+          export XPU_MONITOR_PID_FILEPATH="$(echo ${XPU_MONITOR_PID_FILEPATH} | sed 's/\//\\\//g')" &&
+          export SED_PATTERN="s/pid_fn = str('\/tmp\/xpu_monitor.pid')/pid_fn = str('${XPU_MONITOR_PID_FILEPATH}')/g" &&
+          echo "SED_PATTERN=${SED_PATTERN}" &&
+          sed -i "${SED_PATTERN}" ${WORK_DIRECTORY}/training/kunlunxin/kunlunxin_monitor.py
+
+      # 6.7 Run test
+      - name: 6.7 Run test
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+        run: |
+          pushd ${WORK_DIRECTORY}/training &&
+          python3 run_benchmarks/run.py 2>&1 | tee tmp_run.log &&
+          popd
+
+      # 7. Verify test result
+      - name: 7.1 Verify 1x1 case result
+        if: ${{ inputs.case1x1 != '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+          RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
+        run: |
+          echo "LOG_FILEPATH=${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/rank0.out.log" &&
+          grep '"event": "FINISHED"' "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/rank0.out.log" > /dev/null
+
+      - name: 7.2 Verify 1x8 case result
+        if: ${{ inputs.case1x8 != '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+          RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
+        run: |
+          echo "LOG_FILEPATH=${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/rank0.out.log" &&
+          grep '"event": "FINISHED"' "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/rank0.out.log" > /dev/null
+
+      # 8.1 Fetch 1x1 kunlunxin_monitor result
+      - name: 8.1 Fetch 1x1 kunlunxin_monitor result
+        if: ${{ inputs.case1x1 != '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+          RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
+        run: |
+          cat "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/kunlunxin_monitor.log" || true
+        
+      # 8.2 Get 1x1 kunlunxin_monitor max memory usage
+      - name: 8.2 Get 1x1 kunlunxin_monitor max memory usage
+        if: ${{ inputs.case1x1 != '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+          RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
+        run: |
+          cat "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x1 }}/round1/127.0.0.1_noderank0/kunlunxin_monitor.log" | \
+          grep 'MiB' | \
+          awk '{ print $3 }' | \
+          sed "s/MiB//g" | \
+          sort -n | \
+          tail -n 1 | \
+          xargs -I{} printf "1x1 case max memory usage: {} MB\n" || true
+
+      # 8.3 Fetch 1x8 kunlunxin_monitor result
+      - name: 8.3 Fetch 1x8 kunlunxin_monitor result
+        if: ${{ inputs.case1x8 != '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+          RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
+        run: |
+          cat "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/kunlunxin_monitor.log" || true
+
+      # 8.4 Get 1x8 kunlunxin_monitor max memory usage
+      - name: 8.4 Get 1x8 kunlunxin_monitor max memory usage
+        if: ${{ inputs.case1x8 != '' }}
+        env:
+          WORK_DIRECTORY: ${{ steps.work-directory.outputs.WORK_DIRECTORY }}
+          RUN_RESULT_NAME: ${{ steps.run-result-name.outputs.RUN_RESULT_NAME }}
+        run: |
+            cat "${WORK_DIRECTORY}/training/result/${RUN_RESULT_NAME}/${{ inputs.case1x8 }}/round1/127.0.0.1_noderank0/kunlunxin_monitor.log" | \
+            grep 'MiB' | \
+            awk '{ print $3 }' | \
+            sed "s/MiB//g" | \
+            sort -n | \
+            tail -n 1 | \
+            xargs -I{} printf "1x8 case max memory usage: {} MB\n" || true
+
+      # 9. Remove training container and image
+      - name: 9. Remove training container and image
+        if: ${{ always() && (inputs.case1x1 != '' || inputs.case1x8 != '' )}}
+        env:
+          WORK_TIMESTAMP: ${{ steps.work-timestamp.outputs.WORK_TIMESTAMP }}
+          MODEL_NAME: ${{ steps.get-model-name.outputs.MODEL_NAME }}
+        run: |
+          export WORK_IMAGE_NAME=flagperf-kunlunxin-pytorch:t_v0.1_${MODEL_NAME:-unknown}_${WORK_TIMESTAMP:-unknown} &&
+          echo "WORK_IMAGE_NAME=${WORK_IMAGE_NAME}" &&
+          docker rm -f $(docker ps -a -q --filter ancestor=${WORK_IMAGE_NAME}) || true &&
+          docker rmi -f ${WORK_IMAGE_NAME} || true

--- a/training/kunlunxin/kunlunxin_monitor.py
+++ b/training/kunlunxin/kunlunxin_monitor.py
@@ -258,8 +258,12 @@ def main():
     sys_fn = str(log_path + '/sys_info.log')
     cmd = get_system_info()
     with open(sys_fn, "w") as f:
-        p = subprocess.Popen(cmd, shell=True, stdout=f, stderr=subprocess.STDOUT)
-        p.wait()
+        try:
+            # this command need sudo privilege, may raise exception
+            p = subprocess.Popen(cmd, shell=True, stdout=f, stderr=subprocess.STDOUT)
+            p.wait()
+        except:
+            pass
 
     subdaemon = Daemon(pid_fn,
                        log_fn,


### PR DESCRIPTION
测试workflow完整示例可参考：https://github.com/dynamicheart/FlagPerf/actions/runs/6977313432/job/18987019681?pr=2

1.  PR的标题（强制）需按照`[kunlunxin][MODEL_NAME][DATASET_PATH] xxx`的格式即可自动触发CI。PR的描述里可以传入三个参数（可选）：`MAX_EPOCH`、`PIP_SOURCE`、`MAX_SAMPLES_TERMINATION`：
![image](https://github.com/FlagOpen/FlagPerf/assets/19570241/6b3ecfe8-6929-4529-918f-8e97c9b7c4ae)


2. 需要部署self-hosted  runner，并且打上三个标签：self-hosted、klx、r480，并且设置代理，使其可以与github通信。

     部署self-hosted runner的方法：[链接](https://yikun.github.io/2020/04/17/%E8%AE%A9Github-Action%E5%9C%A8%E4%BD%A0%E8%87%AA%E5%B7%B1%E7%9A%84%E6%9C%BA%E5%99%A8%E4%B8%8A%E8%B7%91%E8%B5%B7%E6%9D%A5/)
注意点：
     -  添加self-hosted runner, 执行config.sh和run.sh 之前需要加上代理 
     示例：`http_prpxy=<YOUR_PROXY_ADDR>  && https_prpxy=<YOUR_PROXY_ADDR> && config.sh 以及 
http_prpxy=<YOUR_PROXY_ADDR> && https_prpxy=<YOUR_PROXY_ADDR>` && run.sh
     - 在参考github的Add new self-hosted runner 文档，执行`./config.sh --url https://github.com/\<username\>/FlagPerf --token <YOUR_TOKEN>` 之前，需要先刷新github的文档页面获取**最新token**，否则可能会因为tokenk过期，返回请求接口 404 NOT Found错误。

3. 为保证安全，建议在self-hosted runner机器上，新建一个ci用户(无sudo权限)，使用ci用户来运行self-hosted  runner程序。注意点：
    - 新建的用户同样要配置本机的ssh免密登录(免密登录`127.0.0.1`)，才能使用run.py一键启动程序；
    - 需要将ci用户加到docker用户组，使得ci用户有权限执行docker命令。
    - **【遗留问题】需要限制ci用户的可访问权限**
    - **【遗留问题】可能得考虑下，docker mount目录的风险(可以mount任意目录作为数据集目录，容易被攻击)**
    - **【遗留问题】用于ci的机器建议跟其它机器隔离、网络隔离（避免被端口扫描），删除ssh key**
    - **【TODO】安全问题解决方法：后续可以加上需要有人approve之后才能触发CI**

4. 【已完成】需要修改run.py在训练失败时返回错误码/或者提供其他机制能够使得actions可以判断训练是否成功。（可能可以考虑使用rank0.log日志文件里面的`Event.FINISHED`事件）

5. 【已完成】需要建立一个机制（例如，设置max_epoch），使得1x1和1x8可以在适当的时间中断训练，防止ci时间过长。
    - 设置了`max_epoch=1`以及`max_samples_termination=20`

6. 【已完成】每次运行时会将run.py里面的VERSION设置为`v0.1_<model_name>_<timestamp>`，保证每次运行都会进行新镜像的构建，并且在运行结束时删除该镜像，回收空间。此外，还额外提供了一个workflow: klx-training-remove-image，可以手动触发删除无用镜像。

本workflow包含的机制有：
- 识别解析PR标题自动触发CI机制
- 输入参数校验机制，防止输入恶意参数造成未知系统错误
- 根据rank0.log里面是否有`FINISHED`判断训练是否成功
- 根据时间戳设置镜像的TAG保证每次构建最新镜像
- CI无论成功和失败自动清理镜像和容器，防止硬盘空间占用过大
- 通过设置max_epoch和max_samples_termination限制CI时长
- 分布式训练随机选择端口防止端口冲突
- 自动拉取xpu_smi数据获取CI过程中的最大峰值内存

解决的问题有:
- 解决非sudo状态下运行run.py无法启动xpu_smi monotor的问题

【补充】手动触发的方法：

选择klx-training-test-manually workflow，传入case、dataset路径等参数，手动触发：

![image](https://github.com/FlagOpen/FlagPerf/assets/19570241/6aa15e1e-7090-4bdf-9a87-18d1aa773ae3)

手动触发ci的教程：https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow


【补充】清理镜像workflow可参考：

https://github.com/dynamicheart/FlagPerf/actions/runs/6940580129