### PR TITLE
【BAAI】fix get_system_info for iluvatar_monitor

### DIFF
--- a/training/iluvatar/iluvatar_monitor.py
+++ b/training/iluvatar/iluvatar_monitor.py
@@ -231,7 +231,7 @@ def get_system_info():
     cmd = cmd + r"echo ;"
     
     cmd = cmd + r"echo Accelerator Model:;"
-    cmd = cmd + r"ixsmi -L;"
+    cmd = cmd + r"export PATH=/usr/local/corex/bin:$PATH; export LD_LIBRARY_PATH=/usr/local/corex/lib; ixsmi -L;"
     cmd = cmd + r"echo ;"
     
     cmd = cmd + r"echo Accelerator Driver version:;"


### PR DESCRIPTION
修改前
![image](https://github.com/FlagOpen/FlagPerf/assets/10068952/56a5e028-f10a-4a1b-be7d-7658b766c096)

修改后

![image](https://github.com/FlagOpen/FlagPerf/assets/10068952/aa33d13b-3430-465d-8a80-c27985c4cc9b)
