### PR TITLE
[kunlunxin] Fix the loss equal to nan problem during mask-rcnn training

### DIFF
--- a/training/kunlunxin/mask_rcnn-pytorch/config/config_R300x1x1.py
+++ b/training/kunlunxin/mask_rcnn-pytorch/config/config_R300x1x1.py
@@ -4,4 +4,5 @@ distributed = False
 
 train_batch_size = 8
 eval_batch_size = 8
-lr = 0.16
+lr = 0.08
+


### PR DESCRIPTION
During the training of Mask-RCNN on a single node with one XPU device, the loss occasionally reached nan  in certain steps.
Down-scaling the learning rate to 0.08 fixed the problem.