### PR TITLE
fix llama3_8B & llama3_70B patch operation

### DIFF
--- a/training/benchmarks/llama3_70B/megatron/run_pretraining.py
+++ b/training/benchmarks/llama3_70B/megatron/run_pretraining.py
@@ -59,20 +59,9 @@ if __name__ == "__main__":
 
     task_log_file = os.path.join(args.log_dir, "megatron.log.txt")
     
-    # merge llama3 patch
-
-    
-    origin_file = os.path.join(megapath, "megatron/training/arguments.py")
-    exec_cmd = "patch --silent --forward " + origin_file + " arguments.patch -o tmp.py;mv tmp.py " + origin_file
-    exec_cmd = exec_cmd + ";"
-    
-    origin_file = os.path.join(megapath, "megatron/training/tokenizer/tokenizer.py")
-    exec_cmd = exec_cmd + "patch --silent --forward " + origin_file + " tokenizer.patch -o tmp.py;mv tmp.py " + origin_file
-    exec_cmd = exec_cmd + ";"
-    
     # bash pretrain_llama3.sh
     
-    exec_cmd = exec_cmd + "bash pretrain_llama3.sh"
+    exec_cmd = "bash pretrain_llama3.sh"
     
     # args
 

--- a/training/benchmarks/llama3_8B/megatron/run_pretraining.py
+++ b/training/benchmarks/llama3_8B/megatron/run_pretraining.py
@@ -59,20 +59,9 @@ if __name__ == "__main__":
 
     task_log_file = os.path.join(args.log_dir, "megatron.log.txt")
     
-    # merge llama3 patch
-
-    
-    origin_file = os.path.join(megapath, "megatron/training/arguments.py")
-    exec_cmd = "patch --silent --forward " + origin_file + " arguments.patch -o tmp.py;mv tmp.py " + origin_file
-    exec_cmd = exec_cmd + ";"
-    
-    origin_file = os.path.join(megapath, "megatron/training/tokenizer/tokenizer.py")
-    exec_cmd = exec_cmd + "patch --silent --forward " + origin_file + " tokenizer.patch -o tmp.py;mv tmp.py " + origin_file
-    exec_cmd = exec_cmd + ";"
-    
     # bash pretrain_llama3.sh
     
-    exec_cmd = exec_cmd + "bash pretrain_llama3.sh"
+    exec_cmd = "bash pretrain_llama3.sh"
     
     # args
 


### PR DESCRIPTION
1、问题背景
寒武纪团队适配flagperf中的llama3_8B、llama3_70B时，发现代码位置FlagPerf/training/benchmarks/llama3_8B/megatron/run_pretraining.py 和
FlagPerf/training/benchmarks/llama3_70B/megatron/run_pretraining.py 中，存在运行时执行patch操作，该patch内容是向Megatron-LM仓库源文件中写入Llama3Tokenizer的实现。

2、问题说明
由于不同适配厂商使用的Megatron-LM版本不一致，因此patch文件中代码行数位置与实际不能完全匹配，导致patch后的代码位置出错，进一步导致启动训练出错。

3、修改建议
建议删除运行时执行patch的操作，提醒使用者根据具体的Megatron版本，在运行前修改本地的patch文件（arguments.patch和tokenizer.patch），并完成patch操作。
