### PR TITLE
fix patch with cambricon & multi nodes

### DIFF
--- a/training/benchmarks/llama3_70B/megatron/run_pretraining.py
+++ b/training/benchmarks/llama3_70B/megatron/run_pretraining.py
@@ -61,18 +61,20 @@ if __name__ == "__main__":
     
     # merge llama3 patch
 
-    
-    origin_file = os.path.join(megapath, "megatron/training/arguments.py")
-    exec_cmd = "patch --silent --forward " + origin_file + " arguments.patch -o tmp.py;mv tmp.py " + origin_file
-    exec_cmd = exec_cmd + ";"
-    
-    origin_file = os.path.join(megapath, "megatron/training/tokenizer/tokenizer.py")
-    exec_cmd = exec_cmd + "patch --silent --forward " + origin_file + " tokenizer.patch -o tmp.py;mv tmp.py " + origin_file
-    exec_cmd = exec_cmd + ";"
-    
-    # bash pretrain_llama3.sh
-    
-    exec_cmd = exec_cmd + "bash pretrain_llama3.sh"
+    if args.vendor=="cambricon":
+        exec_cmd = "bash pretrain_llama3.sh"
+    else:      
+        origin_file = os.path.join(megapath, "megatron/training/arguments.py")
+        exec_cmd = "patch --silent --forward " + origin_file + " arguments.patch -o tmp.py;mv tmp.py " + origin_file
+        exec_cmd = exec_cmd + ";"
+        
+        origin_file = os.path.join(megapath, "megatron/training/tokenizer/tokenizer.py")
+        exec_cmd = exec_cmd + "patch --silent --forward " + origin_file + " tokenizer.patch -o tmp.py;mv tmp.py " + origin_file
+        exec_cmd = exec_cmd + ";"
+        
+        # bash pretrain_llama3.sh
+        
+        exec_cmd = exec_cmd + "bash pretrain_llama3.sh"
     
     # args
 

--- a/training/benchmarks/llama3_8B/megatron/run_pretraining.py
+++ b/training/benchmarks/llama3_8B/megatron/run_pretraining.py
@@ -61,18 +61,20 @@ if __name__ == "__main__":
     
     # merge llama3 patch
 
-    
-    origin_file = os.path.join(megapath, "megatron/training/arguments.py")
-    exec_cmd = "patch --silent --forward " + origin_file + " arguments.patch -o tmp.py;mv tmp.py " + origin_file
-    exec_cmd = exec_cmd + ";"
-    
-    origin_file = os.path.join(megapath, "megatron/training/tokenizer/tokenizer.py")
-    exec_cmd = exec_cmd + "patch --silent --forward " + origin_file + " tokenizer.patch -o tmp.py;mv tmp.py " + origin_file
-    exec_cmd = exec_cmd + ";"
-    
-    # bash pretrain_llama3.sh
-    
-    exec_cmd = exec_cmd + "bash pretrain_llama3.sh"
+    if args.vendor=="cambricon":
+        exec_cmd = "bash pretrain_llama3.sh"
+    else:    
+        origin_file = os.path.join(megapath, "megatron/training/arguments.py")
+        exec_cmd = "patch --silent --forward " + origin_file + " arguments.patch -o tmp.py;mv tmp.py " + origin_file
+        exec_cmd = exec_cmd + ";"
+        
+        origin_file = os.path.join(megapath, "megatron/training/tokenizer/tokenizer.py")
+        exec_cmd = exec_cmd + "patch --silent --forward " + origin_file + " tokenizer.patch -o tmp.py;mv tmp.py " + origin_file
+        exec_cmd = exec_cmd + ";"
+        
+        # bash pretrain_llama3.sh
+        
+        exec_cmd = exec_cmd + "bash pretrain_llama3.sh"
     
     # args
 

--- a/utils/run_cmd.py
+++ b/utils/run_cmd.py
@@ -10,6 +10,7 @@ def run_cmd_wait(cmd, timeout):
     '''Run a shell command and wait <timeout> second(s).'''
     process = subprocess.Popen(cmd,
                                shell=True,
+                               executable="/bin/bash",
                                stdout=subprocess.PIPE,
                                stderr=subprocess.STDOUT,
                                encoding='utf-8')


### PR DESCRIPTION
寒武纪团队适配flagperf时，遇到下述两个问题：
1、运行时patch操作受版本影响，关联的PR为：https://github.com/FlagOpen/FlagPerf/pull/632
现在此PR重新修改。

2、在多机训练时，subprocess.Popen运行外部命令或脚本时创建子进程，并捕获其输出，但此处未能捕获到子进程的输出，导致多机训练启动后卡住。关联的issue为https://github.com/FlagOpen/FlagPerf/issues/560
排查问题后发现是Popen函数中未显示指定执行（executable）命令的shell为/bin/bash。在寒武纪镜像中，此处使用的shell默认是/bin/sh，符号链接指向的是dash。因此建议这里的Popen显示指定具有更多扩展特性的/bin/bash。
现在此PR中修改。

3、可以通过下述代码查看subprocess执行时使用的默认shell
import subprocess
cmd = 'echo $0'  # $0 通常显示当前 shell 的名称或路径
result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
print("echo is " ,result.stdout.strip())