### PR TITLE
cambricon: fix bitwise perf test's input not in device

### DIFF
--- a/operation/benchmarks/bitwise_and/main.py
+++ b/operation/benchmarks/bitwise_and/main.py
@@ -72,9 +72,9 @@ def main(config, case_config):
     mape_std = torch.std(torch.tensor(mmape))
 
     a = torch.randn(m, 1024, 1024) 
-    a = (127 * a).to(torch.int8)
+    a = (127 * a).to(torch.int8).to(0)
     b = torch.randn(m, 1024, 1024) 
-    b = (127 * b).to(torch.int8)
+    b = (127 * b).to(torch.int8).to(0)
 
     latency_nowarm, latency_warm, cputime, kerneltime = do_test(
         torch.bitwise_and, (a, b), host_device_sync, config, case_config)

--- a/operation/benchmarks/bitwise_not/main.py
+++ b/operation/benchmarks/bitwise_not/main.py
@@ -69,7 +69,7 @@ def main(config, case_config):
     mape_std = torch.std(torch.tensor(mmape))
 
     a = torch.randn(m, 1024, 1024) 
-    a = (127 * a).to(torch.int8)
+    a = (127 * a).to(torch.int8).to(0)
 
     latency_nowarm, latency_warm, cputime, kerneltime = do_test(
         torch.bitwise_not, (a, ), host_device_sync, config, case_config)

--- a/operation/benchmarks/bitwise_or/main.py
+++ b/operation/benchmarks/bitwise_or/main.py
@@ -72,9 +72,9 @@ def main(config, case_config):
     mape_std = torch.std(torch.tensor(mmape))
 
     a = torch.randn(m, 1024, 1024) 
-    a = (127 * a).to(torch.int8)
+    a = (127 * a).to(torch.int8).to(0)
     b = torch.randn(m, 1024, 1024) 
-    b = (127 * b).to(torch.int8)
+    b = (127 * b).to(torch.int8).to(0)
 
     latency_nowarm, latency_warm, cputime, kerneltime = do_test(
         torch.bitwise_or, (a, b), host_device_sync, config, case_config)


### PR DESCRIPTION
fix bitwise perf test's input not in device