### PR TITLE
feat(cambricon):improve sys_monitor.py and llava1.5b for cambricon mlu

### DIFF
--- a/base/run.py
+++ b/base/run.py
@@ -143,8 +143,7 @@ def clear_caches_cluster(clear, nnodes):
 
 def start_monitors_in_cluster(dp_path, case_log_dir, nnodes, config):
     '''Start sytem and vendor's monitors.'''
-    start_mon_cmd = "cd " + dp_path + " && " + sys.executable \
-                    + " ../utils/sys_monitor.py -o restart -l "
+    start_mon_cmd = "cd " + dp_path + " && " + sys.executable + " ../utils/sys_monitor.py -v " + config.VENDOR +  " -o restart -l "
     timeout = 60
     RUN_LOGGER.debug("Run cmd in the cluster to start system monitors: " +
                      start_mon_cmd)

--- a/training/benchmarks/llava1.5_13b/deepspeed-torch/evaluate/evaluator.py
+++ b/training/benchmarks/llava1.5_13b/deepspeed-torch/evaluate/evaluator.py
@@ -1,3 +1,8 @@
+# cambricon mlu import
+try:
+    from torch_mlu.utils.model_transfer import transfer
+except ImportError:
+    pass
 import os
 import sys
 import torch

--- a/training/benchmarks/llava1.5_13b/deepspeed-torch/train/train_mem.py
+++ b/training/benchmarks/llava1.5_13b/deepspeed-torch/train/train_mem.py
@@ -1,3 +1,8 @@
+# cambricon mlu import
+try:
+    from torch_mlu.utils.model_transfer import transfer
+except ImportError:
+    pass
 from train import train
 
 if __name__ == "__main__":

--- a/training/benchmarks/llava1.5_7b/deepspeed-torch/evaluate/evaluator.py
+++ b/training/benchmarks/llava1.5_7b/deepspeed-torch/evaluate/evaluator.py
@@ -1,3 +1,8 @@
+# cambricon mlu import
+try:
+    from torch_mlu.utils.model_transfer import transfer
+except ImportError:
+    pass
 import os
 import sys
 import torch

--- a/training/benchmarks/llava1.5_7b/deepspeed-torch/train/train_mem.py
+++ b/training/benchmarks/llava1.5_7b/deepspeed-torch/train/train_mem.py
@@ -1,3 +1,8 @@
+# cambricon mlu import
+try:
+    from torch_mlu.utils.model_transfer import transfer
+except ImportError:
+    pass
 from train import train
 
 if __name__ == "__main__":

--- a/training/run_benchmarks/run.py
+++ b/training/run_benchmarks/run.py
@@ -235,8 +235,7 @@ def clear_caches_cluster(clear, nnodes):
 
 def start_monitors_in_cluster(dp_path, case_log_dir, nnodes):
     '''Start sytem and vendor's monitors.'''
-    start_mon_cmd = "cd " + dp_path + " && " + sys.executable \
-                    + " ../utils/sys_monitor.py -o restart -l "
+    start_mon_cmd = "cd " + dp_path + " && " + sys.executable + " ../utils/sys_monitor.py -o restart -v " + tc.VENDOR + " -l "
     timeout = 60
     RUN_LOGGER.debug("Run cmd in the cluster to start system monitors: " +
                      start_mon_cmd)

--- a/utils/sys_monitor.py
+++ b/utils/sys_monitor.py
@@ -39,6 +39,7 @@ class Daemon:
                  stderr=os.devnull,
                  home_dir='.',
                  umask=0o22,
+                 vendor="nvidia",
                  verbose=0):
         self.stdin = stdin
         self.stdout = stdout
@@ -58,6 +59,7 @@ class Daemon:
         self.umask = umask
         self.verbose = verbose
         self.daemon_alive = True
+        self.vendor=vendor
 
     def get_pid(self):
         try:
@@ -102,6 +104,10 @@ class Daemon:
             TIMESTAMP = datetime.datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
             cmd = "ipmitool sdr list|grep -i Watts|awk 'BEGIN{FS = \"|\"}{for (f=1; f <= NF; f+=1) {if ($f ~ /Watts/)" \
                   " {print $f}}}'|awk '{print $1}'|sort -n -r|head -n1"
+            # support cambriocn mlu 
+            if "cambricon" in self.vendor:
+                cmd = "echo $(( $(ipmitool sdr list | grep -i Watts | awk 'BEGIN{FS=\"|\"} {for (f=1; f<=NF; f++) {if ($f ~ /Watts/) print $f}}' | awk '{print $1}' | sort -n -r | head -n 1) + $(cnmon info -c 0 | grep 'Machine' | awk '{print $3}') ))"
+            
             res, out = rcw(cmd, 10)
             if res:
                 result = "error"
@@ -249,6 +255,12 @@ def parse_args():
                        required=False,
                        default='./logs/',
                        help='log path')
+    parse.add_argument('-v',
+                       type=str,
+                       metavar='[vendor]',
+                       required=False,
+                       default='nvidia',
+                       help='gpu vendor')
     args = parse.parse_args()
     return args
 
@@ -258,6 +270,7 @@ def main():
     sample_rate2 = 120
     args = parse_args()
     operation = args.o
+    vendor=args.v
     path = args.l
     pid_fn = str('/tmp/sys_monitor.pid')
     log_fn = str(path + '/sys_monitor.log')
@@ -268,6 +281,7 @@ def main():
                        err_fn,
                        path,
                        verbose=1,
+                       vendor=vendor,
                        rate1=sample_rate1,
                        rate2=sample_rate2)
     if operation == 'start':


### PR DESCRIPTION
# What Does This PR Do?
寒武纪团队针对自身软件栈的适配需求对flagperf代码进行修改适配，适配改动如下：

## 适配utils/sys_monitor.py

- 当前ipmitool命令在寒武纪平台仅获取到机头服务器功耗，不包括box功耗，适配后的代码获取的功耗包括机头服务器功耗+box功耗，即整机功耗。

- utils/sys_monitor.py 添加传入vendor支持以此来识别cambricon mlu，默认vendor=“nvidia”,不对其他厂家产生影响

- base/run.py 调用sys_monitor.py处 传入-v 以此来识别cambricon mlu

- training/run_benchmarks/run.py 调用sys_monitor.py处 传入-v 以此来识别cambricon mlu

## 适配llava1.5 7b/13b

- train_mem.py和evaluator.py引入对寒武纪软件栈的支持，同时不会对其他设备产生影响。（已测试）