### PR TITLE
FlagPerf Benchmark 支持寒武纪芯片

### DIFF
--- a/base/benchmarks/computation-BF16/main.py
+++ b/base/benchmarks/computation-BF16/main.py
@@ -3,6 +3,13 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
+
+# cambricon mlu import
+try:
+    from torch_mlu.utils.model_transfer import transfer
+except ImportError:
+    pass
+
 import torch
 import torch.distributed as dist
 import os

--- a/base/benchmarks/computation-FP16/main.py
+++ b/base/benchmarks/computation-FP16/main.py
@@ -3,6 +3,13 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
+
+# cambricon mlu import
+try:
+    from torch_mlu.utils.model_transfer import transfer
+except ImportError:
+    pass
+
 import torch
 import torch.distributed as dist
 import os

--- a/base/benchmarks/computation-FP32/main.py
+++ b/base/benchmarks/computation-FP32/main.py
@@ -3,6 +3,13 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
+
+# cambricon mlu import
+try:
+    from torch_mlu.utils.model_transfer import transfer
+except ImportError:
+    pass
+
 import torch
 import torch.distributed as dist
 import os

--- a/base/benchmarks/computation-TF32/main.py
+++ b/base/benchmarks/computation-TF32/main.py
@@ -3,6 +3,13 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
+
+# cambricon mlu import
+try:
+    from torch_mlu.utils.model_transfer import transfer
+except ImportError:
+    pass
+
 import torch
 import torch.distributed as dist
 import os

--- a/base/benchmarks/interconnect-MPI_interserver/main.py
+++ b/base/benchmarks/interconnect-MPI_interserver/main.py
@@ -3,6 +3,13 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
+
+# cambricon mlu import
+try:
+    from torch_mlu.utils.model_transfer import transfer
+except ImportError:
+    pass
+
 import torch
 import torch.distributed as dist
 import os

--- a/base/benchmarks/interconnect-MPI_intraserver/main.py
+++ b/base/benchmarks/interconnect-MPI_intraserver/main.py
@@ -3,6 +3,13 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
+
+# cambricon mlu import
+try:
+    from torch_mlu.utils.model_transfer import transfer
+except ImportError:
+    pass
+
 import torch
 import torch.distributed as dist
 import os

--- a/base/benchmarks/interconnect-P2P_interserver/main.py
+++ b/base/benchmarks/interconnect-P2P_interserver/main.py
@@ -3,6 +3,13 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
+
+# cambricon mlu import
+try:
+    from torch_mlu.utils.model_transfer import transfer
+except ImportError:
+    pass
+
 import torch
 import torch.distributed as dist
 import os

--- a/base/benchmarks/interconnect-P2P_intraserver/main.py
+++ b/base/benchmarks/interconnect-P2P_intraserver/main.py
@@ -3,6 +3,13 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
+
+# cambricon mlu import
+try:
+    from torch_mlu.utils.model_transfer import transfer
+except ImportError:
+    pass
+
 import torch
 import torch.distributed as dist
 import os

--- a/base/benchmarks/interconnect-h2d/main.py
+++ b/base/benchmarks/interconnect-h2d/main.py
@@ -3,6 +3,13 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
+
+# cambricon mlu import
+try:
+    from torch_mlu.utils.model_transfer import transfer
+except ImportError:
+    pass
+
 import torch
 import torch.distributed as dist
 import os

--- a/base/benchmarks/main_memory-bandwidth/main.py
+++ b/base/benchmarks/main_memory-bandwidth/main.py
@@ -3,6 +3,13 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
+
+# cambricon mlu import
+try:
+    from torch_mlu.utils.model_transfer import transfer
+except ImportError:
+    pass
+
 import torch
 import torch.distributed as dist
 import os

--- a/base/benchmarks/main_memory-capacity/main.py
+++ b/base/benchmarks/main_memory-capacity/main.py
@@ -53,7 +53,7 @@ def main(config, case_config, rank, world_size, local_rank):
             total_allocated += byte_size
             print(f"Allocated: {total_allocated} MiB")
         except RuntimeError as e:
-            if "CUDA out of memory" in str(e):
+            if "out of memory" in str(e):
                 print(f"CUDA OOM at tensor size {byte_size} MiB. Allocated:{total_allocated} MiB")
                 byte_size //= 2
                 if byte_size < min_byte_size:

--- a/base/benchmarks/main_memory-capacity/main.py
+++ b/base/benchmarks/main_memory-capacity/main.py
@@ -2,6 +2,12 @@
 #
 # Licensed under the Apache License, Version 2.0 (the "License")
 
+# cambricon mlu import
+try:
+    from torch_mlu.utils.model_transfer import transfer
+except ImportError:
+    pass
+
 import torch
 import torch.distributed as dist
 import os


### PR DESCRIPTION
# What Does this PR Do?

寒武纪软件栈为非兼容cuda生态形式，因此对于cuda代码需要在运行代码启动处添加兼容代码，本次PR对每个benchmark项下的main.py插入兼容代码，同时不影响其他GPU,详情见files changed。