### PR TITLE
[cambricon] Fix MLU PID retrieval issue in nnodes FlagScale training

### DIFF
--- a/training/utils/start_task_helper.py
+++ b/training/utils/start_task_helper.py
@@ -51,6 +51,18 @@ def get_extern_module_dir(task_args):
     return extern_module_dir
 
 
+def get_mlu_pid():
+    '''Return the PID of the first process that contains 'MLU_VISIBLE_DEVICES'
+       in its command, or None if not found.
+    '''
+    import subprocess
+    result = subprocess.Popen(['ps', 'aux'], stdout=subprocess.PIPE, text=True)
+    for line in result.stdout:
+        if 'MLU_VISIBLE_DEVICES' in line and 'grep' not in line:
+            return line.split()[1]
+    return None
+
+
 def write_pid_file(pid_file_path, pid_file):
     '''Write pid file for watching the process later.
        In each round of case, we will write the current pid in the same path.
@@ -61,6 +73,12 @@ def write_pid_file(pid_file_path, pid_file):
     file_d = open(pid_file_path, "w")
     file_d.write("%s\n" % os.getpid())
     file_d.close()
+
+    mlu_pid = get_mlu_pid()
+    if mlu_pid:
+        file_d = open(pid_file_path, "w")
+        file_d.write("%s\n" % mlu_pid)
+        file_d.close()
 
 
 def init_flagperf_logger(logger, task_args):


### PR DESCRIPTION
1、原始代码说明
对于多机训练，主节点在ssh到每个节点后启动flagscale进程（包括主节点），启动进程时获取该进程PID。先将在前一个节点保存的PID文件删除，然后重新覆写入当前节点的PID，直至达到最后一个节点。

2、问题说明
（1）在寒武纪镜像中执行四机（多机）训练时，主节点在其他子节点依次启动flagscale进程并获取和覆写PID进程号。但是其他节点在启动flagscale后，启动进程（初始化进程）在启动了实际工作的子进程后便退出了，获取的PID也即失效。
（2）wait_for_finish函数中判断传入的PID是否仍在运行，以决定是否中断程序。由于获取的PID失效，所以程序会在各个节点立即提前中止。

3、修改说明
在各个节点启动程序后，通过 ps -aux | grep "MLU_VISIBLE_DEVICES"获取真正运行的进程号，并保存在文件中。
