### PR TITLE
[cambricon] Resolve infinite loop issue when retrieving logs

### DIFF
--- a/training/benchmarks/llava1.5_7b_continuetrain/flagscale/run_pretraining.py
+++ b/training/benchmarks/llava1.5_7b_continuetrain/flagscale/run_pretraining.py
@@ -205,8 +205,8 @@ if __name__ == "__main__":
         args.log_dir, "outputs_llava1.5", "logs", "host_" +
         str(timestamp_log_noderank) + "_" + timestamp_log_host + ".output")
 
-    info_line = []
     while True:
+        info_line = []
         try:
             with open(timestamp_log_file, 'r') as f:
                 lines = f.readlines()


### PR DESCRIPTION
1、原始代码说明
在while循环外创建info_line列表，循环内每次间隔300秒访问生成的log文件，并将含有"elapsed time per iteration"字符串的信息append到info_line列表中，只有当列表长度等于迭代步数 getattr(module, "steps") 时跳出while循环。

2、问题说明
当while循环访问到未完成包含所有信息的log时，已有的部分信息仍然会被append到info_line列表；下一次间隔300秒后，会再次将完整的（假设此时log已完成记录所有迭代步）信息append。则列表长度大于getattr(module, "steps")，则一直处于while循环内空转，导致进程无法结束。

3、修改说明
将info_line列表的初始化放在while循环内，每一次append都是独立操作，直到获得完整迭代数，满足跳出while循环条件。